### PR TITLE
Refactor slider path logic

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -433,6 +433,30 @@ module.exports = {
     ],
   ],
   plugins: [
+    [
+      './src/plugins/SliderPlugin',
+      {
+        id: 'infographics',
+        basePath: 'img/infographics',
+        pattern: '**/*.{png,jpg,jpeg,svg,mp4}',
+      },
+    ],
+    [
+      './src/plugins/SliderPlugin',
+      {
+        id: 'industry-applications',
+        basePath: 'img/participate/use-cases/industry-applications',
+        pattern: '**/*.{png,jpg,jpeg,svg,mp4}',
+      },
+    ],
+    [
+      './src/plugins/SliderPlugin',
+      {
+        id: 'trade-and-supply-chain',
+        basePath: 'img/participate/use-cases/trade-and-supply-chain',
+        pattern: '**/*.{png,jpg,jpeg,svg,mp4}',
+      },
+    ],
     'plugin-image-zoom',
     [
       '@jlvandenhout/docusaurus-plugin-docs-editor',

--- a/internal/learn/media-library/infographics.mdx
+++ b/internal/learn/media-library/infographics.mdx
@@ -11,56 +11,56 @@ with an overview of most of the components of the IOTA ecosystem and help to let
 
 ## Core Protocol
 
-<ImageSlider path='/img/infographics/core_protocol' />
+<ImageSlider id='infographics' path='core_protocol' />
 
 ## Frameworks
 
-<ImageSlider path='/img/infographics/frameworks' />
+<ImageSlider id='infographics' path='frameworks' />
 
 ## Use Cases
 
-<ImageSlider path='/img/infographics/use_cases' />
+<ImageSlider id='infographics' path='use_cases' />
 
 ## IOTA Foundation Projects
 
-<ImageSlider path='/img/infographics/IF_projects' />
+<ImageSlider id='infographics' path='IF_projects' />
 
 ## Standards
 
-<ImageSlider path='/img/infographics/standards' />
+<ImageSlider id='infographics' path='standards' />
 
 ## IOTA Tangle vs Blockchain
 
-<ImageSlider path='/img/infographics/blockchain-vs-tangle' />
+<ImageSlider id='infographics' path='blockchain-vs-tangle' />
 
 ## Smart Contracts
 
-<ImageSlider path='/img/infographics/ISCP' />
+<ImageSlider id='infographics' path='ISCP' />
 
 ## Tokenization
 
-<ImageSlider path='/img/infographics/tokenization' />
+<ImageSlider id='infographics' path='tokenization' />
 
 ## Staking
 
-<ImageSlider path='/img/infographics/staking' />
+<ImageSlider id='infographics' path='staking' />
 
 ## Shimmer
 
-<ImageSlider path='/img/infographics/shimmer' />
+<ImageSlider id='infographics' path='shimmer' />
 
 ## Sharding
 
-<ImageSlider path='/img/infographics/sharding' />
+<ImageSlider id='infographics' path='sharding' />
 
 ## Treasury Vote
 
-<ImageSlider path='/img/infographics/treasury_vote' />
+<ImageSlider id='infographics' path='treasury_vote' />
 
 ## Coordicide (IOTA 2.0)
 
-<ImageSlider path='/img/infographics/Coordicide' />
+<ImageSlider id='infographics' path='Coordicide' />
 
 ## Chrysalis (IOTA 1.5)
 
-<ImageSlider path='/img/infographics/Chrysalis' />
+<ImageSlider id='infographics' path='Chrysalis' />

--- a/internal/participate/use-cases/industry-applications.mdx
+++ b/internal/participate/use-cases/industry-applications.mdx
@@ -7,7 +7,7 @@ import ImageSlider from '@site/src/components/Slider';
 
 # Industry applications
 
-<ImageSlider path='/img/participate/use-cases/industry-applications' />
+<ImageSlider id='industry-applications' />
 
 ### SUSEE
 

--- a/internal/participate/use-cases/trade-and-supply-chain.mdx
+++ b/internal/participate/use-cases/trade-and-supply-chain.mdx
@@ -7,7 +7,7 @@ import ImageSlider from '@site/src/components/Slider';
 
 # Global Trade and Supply Chain
 
-<ImageSlider path='/img/participate/use-cases/trade-and-supply-chain' />
+<ImageSlider id='trade-and-supply-chain' />
 
 ### Zebra
 

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "docusaurus-plugin-hotjar": "^0.0.2",
     "docusaurus-plugin-matomo": "^0.0.3",
     "file-loader": "^6.2.0",
+    "globby": "^13.1.1",
     "hast-util-is-element": "1.1.0",
     "plugin-image-zoom": "flexanalytics/plugin-image-zoom",
     "raw-loader": "^4.0.2",

--- a/src/components/Slider/index.tsx
+++ b/src/components/Slider/index.tsx
@@ -2,12 +2,19 @@ import React from 'react';
 import ImageGallery from 'react-image-gallery';
 import 'react-image-gallery/styles/css/image-gallery.css';
 import useBaseUrl from '@docusaurus/useBaseUrl';
+import { usePluginData } from '@docusaurus/useGlobalData';
 import { useRef } from 'react';
 import { useThemeConfig } from '@docusaurus/theme-common';
 import { ThemeConfig } from '@docusaurus/preset-classic';
 
 export interface ImageSliderProps {
+  id: string;
   path: string;
+}
+
+export interface ImageSliderData {
+  basePath: string;
+  files: Array<string>;
 }
 
 export interface ImageSliderConfig extends ThemeConfig {
@@ -16,19 +23,20 @@ export interface ImageSliderConfig extends ThemeConfig {
   };
 }
 
-export default function ImageSlider({ path }: ImageSliderProps) {
-  const { imageSlider } = useThemeConfig() as ImageSliderConfig;
-  const videoPlaceholder = useBaseUrl(imageSlider.videoPlaceholder);
-  // Import images from the infographics folder
-  function importImages(r) {
-    return r.keys().map((x) => x.replace('.', ''));
-  }
+export default function ImageSlider(props: ImageSliderProps) {
+  const normalizedProps = Object.assign({}, { id: 'default', path: '' }, props);
 
-  // Resolve images relative to the static folder
-  const allImages = importImages(
-    require.context('@site/static/', true, /\.(png|jpe?g|svg|mp4)$/),
-  );
-  const requestedImages = allImages.filter((word) => word.startsWith(path));
+  const { imageSlider } = useThemeConfig() as ImageSliderConfig;
+  const { basePath, files } = usePluginData(
+    'iota-wiki-slider-plugin',
+    normalizedProps.id,
+  ) as ImageSliderData;
+
+  const videoPlaceholder = useBaseUrl(imageSlider.videoPlaceholder);
+
+  const requestedImages = files
+    .filter((file) => file.startsWith(normalizedProps.path))
+    .map((file) => basePath + '/' + file);
 
   // Get file extension
   function getFileExtension(filename) {

--- a/src/plugins/SliderPlugin.js
+++ b/src/plugins/SliderPlugin.js
@@ -1,0 +1,17 @@
+module.exports = (context, options) => ({
+  name: 'iota-wiki-slider-plugin',
+  contentLoaded: async ({ actions }) => {
+    const { globby } = await import('globby');
+    const path = await import('path');
+
+    const results = await Promise.all(
+      context.siteConfig.staticDirectories.map((directory) =>
+        globby(options.pattern, {
+          cwd: path.resolve(directory, options.basePath),
+        }),
+      ),
+    );
+    const files = results.flat();
+    actions.setGlobalData({ basePath: options.basePath, files });
+  },
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -7496,7 +7496,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fast-glob@npm:^3.2.7, fast-glob@npm:^3.2.9":
+"fast-glob@npm:^3.2.11, fast-glob@npm:^3.2.7, fast-glob@npm:^3.2.9":
   version: 3.2.11
   resolution: "fast-glob@npm:3.2.11"
   dependencies:
@@ -8250,6 +8250,19 @@ __metadata:
     merge2: ^1.4.1
     slash: ^4.0.0
   checksum: 2539379a7fff3473d3e7c68b4540ba38f36970f43f760e36e301515d5cb98a0c5736554957d90390906bee632327beb2f9518d1acd6911f61e436db11b0da5b5
+  languageName: node
+  linkType: hard
+
+"globby@npm:^13.1.1":
+  version: 13.1.1
+  resolution: "globby@npm:13.1.1"
+  dependencies:
+    dir-glob: ^3.0.1
+    fast-glob: ^3.2.11
+    ignore: ^5.2.0
+    merge2: ^1.4.1
+    slash: ^4.0.0
+  checksum: e6c43409c6c31b374fbd1c01a8c1811de52336928be9c697e472d2a89a156c9cbf1fb33863755c0447b4db16485858aa57f16628d66a6b7c7131669c9fbe76cd
   languageName: node
   linkType: hard
 
@@ -9141,6 +9154,7 @@ __metadata:
     eslint-plugin-react: ^7.26.0
     eslint-plugin-react-hooks: ^4.2.0
     file-loader: ^6.2.0
+    globby: ^13.1.1
     hast-util-is-element: 1.1.0
     husky: ">=6"
     lint-staged: ">=10"


### PR DESCRIPTION
# Description of change

This is another attempt to refactor the slider path resolving logic. So here I created a small plugin that accepts a base path and pattern to search in the static folders, this removes the hardcoded paths and also the hardcoded path to the static folder. Multiple plugin instances can have different base paths and patterns, so the associated slider component only has to match a subset of paths. Plugin instances and slider components are associated through the plugin id. What do you think of this solution?

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have tested the wiki locally and tested that all external links work
