### PR TITLE
Update shimmer-community-grant-committee.md

### DIFF
--- a/shimmer/learn/governance/shimmer-community-grant-committee.md
+++ b/shimmer/learn/governance/shimmer-community-grant-committee.md
@@ -216,7 +216,7 @@ The teams must provide the following details in an [**application questionnaire 
 
 **This does not imply that automatically such an offer will lead to granting the extra points. Granting these additional points is decided on a case by case basis.**
 
-[**JD Sutton has built a Notion Database for this selection process**](https://airtable.com/shrvZgn3NVsXLTXev/tblAzVWXeTSvUyZI3)
+[**JD Sutton has built the Tangle Treasury website for the selection process**](https://www.tangletreasury.org/proposals)
 
 The scoring system is a guideline for reviewers. We understand that it may only sometimes apply to some kinds of projects.
 


### PR DESCRIPTION
Updated Tangle Treasury website proposal link. The old description and link were incorrect. This change does not change the context of the framework in any way. Instead, it simply updates to the current link.

# Description of change

In shimmer-community-grant-committee.md on code line 219 the description and hyperlink were based on an old test case. Since then, the Notion site has been disregarded, as well, we are now using the TangleTreasury.org/proposals web page for showing how proposals are graded. The hyperlink to the Airtable has been closed down.

## Links to any relevant issues

Fixes #977

## Type of change

- Documentation Fix Typo

## Change checklist

- [x] I have followed the [contribution guidelines](https://github.com/iota-wiki/iota-wiki/blob/main/.github/CONTRIBUTING.md) for this project
- [x] I have performed a self-review of my own changes
- [x] I have made sure that added/changed links still work
- [x] I have commented my code, particularly in hard-to-understand areas
