### PR TITLE
Update preview triggers

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -5,11 +5,14 @@ env:
 on:
   workflow_dispatch:
   pull_request:
-    branches:
-      - main
+    types: [ready_for_review]
+    branches: [main]
+  issue_comment:                                     
+    types: [created]:
 
 jobs:
   build:
+    if: ${{ github.event.issue.pull_request }}
     strategy:
       matrix:
         environment: [iota, shimmer, next]
@@ -17,9 +20,10 @@ jobs:
     with:
       environment: ${{ matrix.environment }}
   config:
+    if: ${{ github.event.issue.pull_request }}
     uses: ./.github/workflows/config.reusable.yaml
   deploy:
-    if: ${{ github.actor != 'dependabot[bot]' }}
+    if: ${{ github.actor != 'dependabot[bot]' && github.event.issue.pull_request && contains(github.event.comment.body, '/create-preview') }}
     runs-on: ubuntu-latest
     needs:
       - build

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -7,12 +7,20 @@ on:
   pull_request:
     types: [ready_for_review]
     branches: [main]
-  issue_comment:                                     
-    types: [created]:
+  issue_comment:
+    types: [created]
 
 jobs:
   build:
-    if: ${{ github.event.issue.pull_request }}
+    if: |
+      github.actor != 'dependabot[bot]' &&
+      (
+        github.event.pull_request || 
+        (
+          github.event.issue.pull_request && 
+          contains(github.event.comment.body, '/create-preview')
+        )
+      )
     strategy:
       matrix:
         environment: [iota, shimmer, next]
@@ -20,10 +28,9 @@ jobs:
     with:
       environment: ${{ matrix.environment }}
   config:
-    if: ${{ github.event.issue.pull_request }}
+    needs: [build]
     uses: ./.github/workflows/config.reusable.yaml
   deploy:
-    if: ${{ github.actor != 'dependabot[bot]' && github.event.issue.pull_request && contains(github.event.comment.body, '/create-preview') }}
     runs-on: ubuntu-latest
     needs:
       - build


### PR DESCRIPTION
# Description of change

With the current preview trigger every commit in a PR will trigger a Preview. Yesterday we run out of preview for that reason and the wiki couldn't build at night. So I changed the workflow to (hopefully :trollface: ) trigger once the PR was marked as `Ready for Review` or someone commented `/create-preview`

## Links to any relevant issues

Fixes #1016 

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## Change checklist

- [x] I have followed the [contribution guidelines](https://github.com/iota-wiki/iota-wiki/blob/main/.github/CONTRIBUTING.md) for this project
- [x] I have performed a self-review of my own changes
- [ ] I have made sure that added/changed links still work
- [ ] I have commented my code, particularly in hard-to-understand areas
