### PR TITLE
Fix  preview workflow for workflow dispatch

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -13,12 +13,15 @@ on:
 jobs:
   build:
     if: |
-      github.actor != 'dependabot[bot]' &&
+      github.event_name == 'workflow_dispatch' ||
       (
-        github.event.pull_request || 
+        github.actor != 'dependabot[bot]' &&
         (
-          github.event.issue.pull_request && 
-          contains(github.event.comment.body, '/create-preview')
+          github.event.pull_request || 
+          (
+            github.event.issue.pull_request && 
+            contains(github.event.comment.body, '/create-preview')
+          )
         )
       )
     strategy:
@@ -63,8 +66,11 @@ jobs:
       - name: Set deploy url
         id: deploy_url
         run: echo "DEPLOY_URL=$(cat vercel_output.txt | awk 'END{print}')" >> $GITHUB_OUTPUT
+      - name: Print deploy url
+        run: echo ${{ steps.deploy_url.outputs.DEPLOY_URL }}
       # Create a comment on the pull request with the deployed URL
       - name: Comment on pull request
+        if: github.event_name != 'workflow_dispatch'
         uses: actions/github-script@v6.4.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
# Description of change

The preview workflow could be triggered by the `workflow_dispatch` event. But the workflow didn't handle it properly until now. I fixed that with another condition, printed the deploy url to the console and ignored the PR comment step if needed.

Run successfully: https://github.com/iotaledger/iota-wiki/actions/runs/5563729522

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## Change checklist

- [x] I have followed the [contribution guidelines](https://github.com/iota-wiki/iota-wiki/blob/main/.github/CONTRIBUTING.md) for this project
- [x] I have performed a self-review of my own changes
- [x] I have made sure that added/changed links still work
- [x] I have commented my code, particularly in hard-to-understand areas
