### PR TITLE
Fix Typescript language tab naming

### DIFF
--- a/common/community/contribute-to-wiki/reference/structure/how_tos.md
+++ b/common/community/contribute-to-wiki/reference/structure/how_tos.md
@@ -38,7 +38,7 @@ snippets), while keeping the language agnostic instructions outside the tabs.
   <TabItem value="java" label="Java">
     Java specific code and text goes here.
   </TabItem>
-  <TabItem value="node" label="Node.js">
+  <TabItem value="typescript-node" label="Typescript (Node.js)">
     Nodejs specific code and text goes here.
   </TabItem>
 </Tabs>

--- a/iota/docs/identity.rs/v0.5.0/docs/concepts/advanced/storage_interface.mdx
+++ b/iota/docs/identity.rs/v0.5.0/docs/concepts/advanced/storage_interface.mdx
@@ -123,7 +123,7 @@ This test suite is available in newer versions of the framework, but not yet in 
 This section shows the Rust and TypeScript `MemStore` implementations, which are thoroughly commented.
 
 <Tabs groupId="language" queryString>
-<TabItem value="node" label="Node.js">
+<TabItem value="typescript-node" label="Typescript (Node.js)">
 
 ```ts reference
 https://github.com/iotaledger/identity.rs/tree/support/v0.5/bindings/wasm/examples-account/src/memory_storage.ts

--- a/iota/docs/identity.rs/v0.5.0/docs/concepts/decentralized_identifiers/create.mdx
+++ b/iota/docs/identity.rs/v0.5.0/docs/concepts/decentralized_identifiers/create.mdx
@@ -31,7 +31,7 @@ Select your programming language of choice and press the green play button to ex
 :::
 
 <Tabs groupId="language" queryString>
-<TabItem value="node" label="Node.js">
+<TabItem value="typescript-node" label="Typescript (Node.js)">
 
 ```ts reference
 https://github.com/iotaledger/identity.rs/blob/support/v0.5/bindings/wasm/examples-account/src/create_did.ts

--- a/iota/docs/identity.rs/v0.5.0/docs/concepts/decentralized_identifiers/private_tangle.mdx
+++ b/iota/docs/identity.rs/v0.5.0/docs/concepts/decentralized_identifiers/private_tangle.mdx
@@ -28,7 +28,7 @@ https://github.com/iotaledger/identity.rs/tree/support/v0.5/examples/account/con
 ### Low-level API
 
 <Tabs groupId="language" queryString>
-<TabItem value="node" label="Node.js">
+<TabItem value="typescript-node" label="Typescript (Node.js)">
 
 ```ts reference
 https://github.com/iotaledger/identity.rs/tree/support/v0.5/bindings/wasm/examples/src/private_tangle.js

--- a/iota/docs/identity.rs/v0.5.0/docs/concepts/decentralized_identifiers/resolve.mdx
+++ b/iota/docs/identity.rs/v0.5.0/docs/concepts/decentralized_identifiers/resolve.mdx
@@ -40,7 +40,7 @@ let doc: ResolvedIotaDocument = resolver.resolve(&did).await?;
 ```
 
 </TabItem>
-<TabItem value="node" label="Node.js">
+<TabItem value="typescript-node" label="Typescript (Node.js)">
 
 ```js
 const { DID, Resolver, ResolvedDocument } = require('@iota/identity-wasm/node');
@@ -81,7 +81,7 @@ async fn build_and_resolve(client: Client, did: IotaDID) -> Result<ResolvedIotaD
 ```
 
 </TabItem>
-<TabItem value="node" label="Node.js">
+<TabItem value="typescript-node" label="Typescript (Node.js)">
 
 ```js
 const {
@@ -139,7 +139,7 @@ async fn call_resolve_history(did: IotaDID) -> Result<DocumentHistory> {
 ```
 
 </TabItem>
-<TabItem value="node" label="Node.js">
+<TabItem value="typescript-node" label="Typescript (Node.js)">
 
 ```js
 const { DID, Resolver, DocumentHistory } = require('@iota/identity-wasm/node');
@@ -159,7 +159,7 @@ async function callResolveHistory(did) {
 This section shows complete examples from the Iota Identity Framework code base. The first example creates a DID Document, publishes it to the Tangle and then resolves it.
 
 <Tabs groupId="language" queryString>
-<TabItem value="node" label="Node.js">
+<TabItem value="typescript-node" label="Typescript (Node.js)">
 
 ```ts reference
 https://github.com/iotaledger/identity.rs/blob/support/v0.5/bindings/wasm/examples/src/resolve_did.js
@@ -178,7 +178,7 @@ https://github.com/iotaledger/identity.rs/blob/support/v0.5/examples/low-level-a
 This second example demonstrates creating, publishing changes and then resolving the history of a DID Document.
 
 <Tabs groupId="language" queryString>
-<TabItem value="node" label="Node.js">
+<TabItem value="typescript-node" label="Typescript (Node.js)">
 
 ```ts reference
 https://github.com/iotaledger/identity.rs/blob/support/v0.5/bindings/wasm/examples/src/resolve_history.js

--- a/iota/docs/identity.rs/v0.5.0/docs/concepts/decentralized_identifiers/update.mdx
+++ b/iota/docs/identity.rs/v0.5.0/docs/concepts/decentralized_identifiers/update.mdx
@@ -73,7 +73,7 @@ The following properties can be specified for a service:
 The following example demonstrates adding verification methods and services to a DID Document.
 
 <Tabs groupId="language" queryString>
-<TabItem value="node" label="Node.js">
+<TabItem value="typescript-node" label="Typescript (Node.js)">
 
 ```ts reference
 https://github.com/iotaledger/identity.rs/blob/support/v0.5/bindings/wasm/examples-account/src/manipulate_did.ts
@@ -104,7 +104,7 @@ let mut account: Account = Account::builder()
 ```
 
 </TabItem>
-<TabItem value="node" label="Node.js">
+<TabItem value="typescript-node" label="Typescript (Node.js)">
 
 ```js
 let builder = new AccountBuilder({
@@ -169,7 +169,7 @@ account
 ```
 
 </TabItem>
-<TabItem value="node" label="Node.js">
+<TabItem value="typescript-node" label="Typescript (Node.js)">
 
 ```js
 await account.createMethod({
@@ -236,7 +236,7 @@ account
 ```
 
 </TabItem>
-<TabItem value="node" label="Node.js">
+<TabItem value="typescript-node" label="Typescript (Node.js)">
 
 ```js
 await account.attachMethodRelationships({
@@ -305,7 +305,7 @@ account
 ```
 
 </TabItem>
-<TabItem value="node" label="Node.js">
+<TabItem value="typescript-node" label="Typescript (Node.js)">
 
 ```js
 await account.createService({
@@ -379,7 +379,7 @@ account
 ```
 
 </TabItem>
-<TabItem value="node" label="Node.js">
+<TabItem value="typescript-node" label="Typescript (Node.js)">
 
 ```js
 await account.deleteMethod({ fragment: 'my-next-key' });

--- a/iota/docs/identity.rs/v0.5.0/docs/concepts/verifiable_credentials/create.mdx
+++ b/iota/docs/identity.rs/v0.5.0/docs/concepts/verifiable_credentials/create.mdx
@@ -84,7 +84,7 @@ The following code exemplifies how an issuer can create, sign, and validate a ve
 This Verifiable Credential can be [verified by anyone](./verifiable_presentations.mdx), allowing Alice to take control of it and share it with anyone.
 
 <Tabs groupId="language" queryString>
-<TabItem value="node" label="Node.js">
+<TabItem value="typescript-node" label="Typescript (Node.js)">
 
 ```ts reference
 https://github.com/iotaledger/identity.rs/blob/support/v0.5/bindings/wasm/examples-account/src/create_vc.ts

--- a/iota/docs/identity.rs/v0.5.0/docs/concepts/verifiable_credentials/revoke.mdx
+++ b/iota/docs/identity.rs/v0.5.0/docs/concepts/verifiable_credentials/revoke.mdx
@@ -46,7 +46,7 @@ Revocation List 2020 is not yet supported in the IOTA Identity Framework
 The following code exemplifies how you can revoke a [Verifiable Credential(VC)](overview.mdx) by removing a verification method (public key) from the DID Document of the Issuer. This means the VC can no longer be validated. This would invalidate every VC signed with the same public key, meaning the Issuer would have to sign every VC with a different key.
 
 <Tabs groupId="language" queryString>
-<TabItem value="node" label="Node.js">
+<TabItem value="typescript-node" label="Typescript (Node.js)">
 
 ```ts reference
 https://github.com/iotaledger/identity.rs/blob/support/v0.5/bindings/wasm/examples-account/src/revoke_vc.ts

--- a/iota/docs/identity.rs/v0.5.0/docs/concepts/verifiable_credentials/verifiable_presentations.mdx
+++ b/iota/docs/identity.rs/v0.5.0/docs/concepts/verifiable_credentials/verifiable_presentations.mdx
@@ -171,7 +171,7 @@ The following code demonstrates how to use the IOTA Identity Framework end-to-en
 serialize it to JSON for transmission, deserialize it on the receiving side as a verifier, and finally validate it with various options.
 
 <Tabs groupId="language" queryString>
-<TabItem value="node" label="Node.js">
+<TabItem value="typescript-node" label="Typescript (Node.js)">
 
 ```ts reference
 https://github.com/iotaledger/identity.rs/blob/support/v0.5/bindings/wasm/examples-account/src/create_vp.ts

--- a/iota/docs/identity.rs/v0.5.0/docs/getting_started/create_and_publish.mdx
+++ b/iota/docs/identity.rs/v0.5.0/docs/getting_started/create_and_publish.mdx
@@ -35,7 +35,7 @@ Select your programming language of choice and press the green play button to ex
 :::
 
 <Tabs groupId="language" queryString>
-<TabItem value="node" label="Node.js">
+<TabItem value="typescript-node" label="Typescript (Node.js)">
 
 ```ts reference
 https://github.com/iotaledger/identity.rs/blob/support/v0.5/bindings/wasm/examples-account/src/create_did.ts

--- a/iota/docs/identity.rs/v0.6.0/docs/concepts/advanced/storage_interface.mdx
+++ b/iota/docs/identity.rs/v0.6.0/docs/concepts/advanced/storage_interface.mdx
@@ -117,7 +117,7 @@ The `StorageTestSuite` can be used to test the basic functionality of storage im
 This section shows the Rust and TypeScript `MemStore` implementations, which are thoroughly commented.
 
 <Tabs groupId="language" queryString>
-<TabItem value="node" label="Node.js">
+<TabItem value="typescript-node" label="Typescript (Node.js)">
 
 ```ts reference
 https://github.com/iotaledger/identity.rs/tree/support/v0.6/bindings/wasm/examples-account/src/custom_storage.ts

--- a/iota/docs/identity.rs/v0.6.0/docs/concepts/decentralized_identifiers/create.mdx
+++ b/iota/docs/identity.rs/v0.6.0/docs/concepts/decentralized_identifiers/create.mdx
@@ -30,7 +30,7 @@ Select your programming language of choice and press the green play button to ex
 :::
 
 <Tabs groupId="language" queryString>
-<TabItem value="node" label="Node.js">
+<TabItem value="typescript-node" label="Typescript (Node.js)">
 
 ```ts reference
 https://github.com/iotaledger/identity.rs/blob/support/v0.6/bindings/wasm/examples-account/src/create_did.ts

--- a/iota/docs/identity.rs/v0.6.0/docs/concepts/decentralized_identifiers/private_tangle.mdx
+++ b/iota/docs/identity.rs/v0.6.0/docs/concepts/decentralized_identifiers/private_tangle.mdx
@@ -28,7 +28,7 @@ https://github.com/iotaledger/identity.rs/tree/support/v0.6/examples/account/con
 ### Low-level API
 
 <Tabs groupId="language" queryString>
-<TabItem value="node" label="Node.js">
+<TabItem value="typescript-node" label="Typescript (Node.js)">
 
 ```ts reference
 https://github.com/iotaledger/identity.rs/tree/support/v0.6/bindings/wasm/examples/src/private_tangle.js

--- a/iota/docs/identity.rs/v0.6.0/docs/concepts/decentralized_identifiers/resolve.mdx
+++ b/iota/docs/identity.rs/v0.6.0/docs/concepts/decentralized_identifiers/resolve.mdx
@@ -40,7 +40,7 @@ let doc: ResolvedIotaDocument = resolver.resolve(&did).await?;
 ```
 
 </TabItem>
-<TabItem value="node" label="Node.js">
+<TabItem value="typescript-node" label="Typescript (Node.js)">
 
 ```js
 const { DID, Resolver, ResolvedDocument } = require('@iota/identity-wasm/node');
@@ -80,7 +80,7 @@ async fn build_and_resolve(client: Client, did: IotaDID) -> Result<ResolvedIotaD
 ```
 
 </TabItem>
-<TabItem value="node" label="Node.js">
+<TabItem value="typescript-node" label="Typescript (Node.js)">
 
 ```js
 const {
@@ -138,7 +138,7 @@ async fn call_resolve_history(did: IotaDID) -> Result<DocumentHistory> {
 ```
 
 </TabItem>
-<TabItem value="node" label="Node.js">
+<TabItem value="typescript-node" label="Typescript (Node.js)">
 
 ```js
 const { DID, Resolver, DocumentHistory } = require('@iota/identity-wasm/node');
@@ -165,7 +165,7 @@ https://github.com/iotaledger/identity.rs/blob/support/v0.6/examples/low-level-a
 ```
 
 </TabItem>
-<TabItem value="node" label="Node.js">
+<TabItem value="typescript-node" label="Typescript (Node.js)">
 
 ```js reference
 https://github.com/iotaledger/identity.rs/blob/support/v0.6/bindings/wasm/examples/src/resolve_did.js
@@ -184,7 +184,7 @@ https://github.com/iotaledger/identity.rs/tree/support/v0.6/examples/low-level-a
 ```
 
 </TabItem>
-<TabItem value="node" label="Node.js">
+<TabItem value="typescript-node" label="Typescript (Node.js)">
 
 ```js reference
 https://github.com/iotaledger/identity.rs/tree/support/v0.6/bindings/wasm/examples/src/resolve_history.js

--- a/iota/docs/identity.rs/v0.6.0/docs/concepts/decentralized_identifiers/update.mdx
+++ b/iota/docs/identity.rs/v0.6.0/docs/concepts/decentralized_identifiers/update.mdx
@@ -80,7 +80,7 @@ https://github.com/iotaledger/identity.rs/blob/support/v0.6/examples/account/man
 ```
 
 </TabItem>
-<TabItem value="node" label="Node.js">
+<TabItem value="typescript-node" label="Typescript (Node.js)">
 
 ```js reference
 https://github.com/iotaledger/identity.rs/blob/support/v0.6/bindings/wasm/examples-account/src/manipulate_did.ts
@@ -104,7 +104,7 @@ let mut account: Account = Account::builder()
 ```
 
 </TabItem>
-<TabItem value="node" label="Node.js">
+<TabItem value="typescript-node" label="Typescript (Node.js)">
 
 ```js
 let builder = new AccountBuilder({
@@ -169,7 +169,7 @@ account
 ```
 
 </TabItem>
-<TabItem value="node" label="Node.js">
+<TabItem value="typescript-node" label="Typescript (Node.js)">
 
 ```js
 await account.createMethod({
@@ -236,7 +236,7 @@ account
 ```
 
 </TabItem>
-<TabItem value="node" label="Node.js">
+<TabItem value="typescript-node" label="Typescript (Node.js)">
 
 ```js
 await account.attachMethodRelationships({
@@ -305,7 +305,7 @@ account
 ```
 
 </TabItem>
-<TabItem value="node" label="Node.js">
+<TabItem value="typescript-node" label="Typescript (Node.js)">
 
 ```js
 await account.createService({
@@ -379,7 +379,7 @@ account
 ```
 
 </TabItem>
-<TabItem value="node" label="Node.js">
+<TabItem value="typescript-node" label="Typescript (Node.js)">
 
 ```js
 await account.deleteMethod({ fragment: 'my-next-key' });

--- a/iota/docs/identity.rs/v0.6.0/docs/concepts/verifiable_credentials/create.mdx
+++ b/iota/docs/identity.rs/v0.6.0/docs/concepts/verifiable_credentials/create.mdx
@@ -90,7 +90,7 @@ https://github.com/iotaledger/identity.rs/blob/support/v0.6/examples/account/cre
 ```
 
 </TabItem>
-<TabItem value="node" label="Node.js">
+<TabItem value="typescript-node" label="Typescript (Node.js)">
 
 ```js reference
 https://github.com/iotaledger/identity.rs/blob/support/v0.6/bindings/wasm/examples-account/src/create_vc.ts

--- a/iota/docs/identity.rs/v0.6.0/docs/concepts/verifiable_credentials/revocation.mdx
+++ b/iota/docs/identity.rs/v0.6.0/docs/concepts/verifiable_credentials/revocation.mdx
@@ -65,7 +65,7 @@ https://github.com/iotaledger/identity.rs/blob/support/v0.6/examples/account/rev
 ```
 
 </TabItem>
-<TabItem value="node" label="Node.js">
+<TabItem value="typescript-node" label="Typescript (Node.js)">
 
 ```ts reference
 https://github.com/iotaledger/identity.rs/blob/support/v0.6/bindings/wasm/examples-account/src/revoke_vc.ts

--- a/iota/docs/identity.rs/v0.6.0/docs/concepts/verifiable_credentials/verifiable_presentations.mdx
+++ b/iota/docs/identity.rs/v0.6.0/docs/concepts/verifiable_credentials/verifiable_presentations.mdx
@@ -177,7 +177,7 @@ https://github.com/iotaledger/identity.rs/blob/support/v0.6/examples/account/cre
 ```
 
 </TabItem>
-<TabItem value="node" label="Node.js">
+<TabItem value="typescript-node" label="Typescript (Node.js)">
 
 ```ts reference
 https://github.com/iotaledger/identity.rs/blob/support/v0.6/bindings/wasm/examples-account/src/create_vp.ts

--- a/iota/docs/identity.rs/v0.6.0/docs/getting_started/create_and_publish.mdx
+++ b/iota/docs/identity.rs/v0.6.0/docs/getting_started/create_and_publish.mdx
@@ -34,7 +34,7 @@ Select your programming language of choice and press the green play button to ex
 :::
 
 <Tabs groupId="language" queryString>
-<TabItem value="node" label="Node.js">
+<TabItem value="typescript-node" label="Typescript (Node.js)">
 
 ```ts reference
 https://github.com/iotaledger/identity.rs/blob/support/v0.6/bindings/wasm/examples-account/src/create_did.ts

--- a/iota/docs/integration-services/docs/how_tos/integration-services-sdk/authenticate-your-identity.mdx
+++ b/iota/docs/integration-services/docs/how_tos/integration-services-sdk/authenticate-your-identity.mdx
@@ -49,7 +49,7 @@ everything may yet run smoothly.
 - [Maven](https://maven.apache.org/)
 
 </TabItem>
-<TabItem value="node" label="Node.js">
+<TabItem value="typescript-node" label="Typescript (Node.js)">
 
 - A recent version of [Node.js](https://nodejs.org/en/download/) (>v16.17.0).
 
@@ -72,7 +72,7 @@ particular:
 - `org.json.*`
 
 </TabItem>
-<TabItem value="node" label="Node.js">
+<TabItem value="typescript-node" label="Typescript (Node.js)">
 
 This example uses `Axios` as the HTTP client, `bs58` to decode Base58, and [@noble/ed25519](https://www.npmjs.com/package/noble-ed25519) to sign the nonce. However, you can use any package as long as it accomplishes the same result.
 
@@ -156,7 +156,7 @@ Never save your secret key in plain text in your code. Use local environment var
 ```
 
 </TabItem>
-<TabItem value="node" label="Node.js">
+<TabItem value="typescript-node" label="Typescript (Node.js)">
 
 ```js title="./authenticate.js"
 import axios from 'axios';
@@ -204,7 +204,7 @@ byte[] convertNonce = DatatypeConverter.parseHexBinary(hashNonceHex);
 ```
 
 </TabItem>
-<TabItem value="node" label="Node.js">
+<TabItem value="typescript-node" label="Typescript (Node.js)">
 
 After you have retrieved the nonce, you should hash it. You can use the Node API's [createHash()](https://nodejs.org/api/crypto.html#hashupdatedata-inputencoding) function to hash the nonce with the SHA-256 hash function and convert it to hexadecimal.{#hashupdatedata-inputencoding) function to hash the nonce with the sha-256 hash function and convert it to hexadecimal.-node}
 
@@ -258,7 +258,7 @@ IOTA [Stronghold](https://wiki.iota.org/stronghold.rs/welcome) to store your sec
 ```
 
 </TabItem>
-<TabItem value="node" label="Node.js">
+<TabItem value="typescript-node" label="Typescript (Node.js)">
 
 ```js title="./authenticate.js"
 import * as ed from '@noble/ed25519';
@@ -316,7 +316,7 @@ this.jwt = response.getString("jwt");
 ```
 
 </TabItem>
-<TabItem value="node" label="Node.js">
+<TabItem value="typescript-node" label="Typescript (Node.js)">
 
 ```js title="./authenticate.js"
 import axios from 'axios';
@@ -392,7 +392,7 @@ This is an example of a GET request to the API with the JWT from the last step i
 ```
 
 </TabItem>
-<TabItem value="node" label="Node.js">
+<TabItem value="typescript-node" label="Typescript (Node.js)">
 
 ```js title="./authenticate.js"
 import axios from 'axios';
@@ -423,7 +423,7 @@ You can find the complete code example in this [repository](https://github.com/a
 All snippets above are taken from there.
 
 </TabItem>
-<TabItem value="node" label="Node.js">
+<TabItem value="typescript-node" label="Typescript (Node.js)">
 
 The following snippet is the final code using all functions together to request a JWT.
 You can find the complete code example at this [repository](https://github.com/Schereo/is-node-authentication))

--- a/iota/docs/integration-services/docs/how_tos/integration-services-sdk/authorize-to-channel.mdx
+++ b/iota/docs/integration-services/docs/how_tos/integration-services-sdk/authorize-to-channel.mdx
@@ -41,7 +41,7 @@ mvn exec:_java -Dexec.mainClass=net.gradbase.how_tos.AuthorizeToChannel
 **Example source code**: [Example-6](https://github.com/albydeca/iota-is-sdk/blob/main/examples/src/main/java/net/gradbase/examples/AuthorizeToChannel.java)
 
 </TabItem>
-<TabItem value="node" label="Node.js">
+<TabItem value="typescript-node" label="Typescript (Node.js)">
 
 ```bash
 npm run example-6
@@ -67,7 +67,7 @@ System.out.println("subscription link " + subscriptionLink);
 ```
 
 </TabItem>
-<TabItem value="node" label="Node.js">
+<TabItem value="typescript-node" label="Typescript (Node.js)">
 
 ```js
 // Request subscription to the channel as the user. The returned subscriptionLink can be used to authorize the user to the channel.
@@ -104,7 +104,7 @@ for (SubscriptionInternal sub : allSubs) {
 ```
 
 </TabItem>
-<TabItem value="node" label="Node.js">
+<TabItem value="typescript-node" label="Typescript (Node.js)">
 
 ```js
 // Find subscriptions to the channel that are not already authorized.
@@ -142,7 +142,7 @@ ownerClient.write(channelAddress, "log", null, new JSONObject().put("log", "This
 ```
 
 </TabItem>
-<TabItem value="node" label="Node.js">
+<TabItem value="typescript-node" label="Typescript (Node.js)">
 
 ```js
 // Writing data to the channel as the channel owner.
@@ -169,7 +169,7 @@ await ownerClient.write(channelAddress, {
 ```
 
 </TabItem>
-    <TabItem value="node" label="Node.js">
+    <TabItem value="typescript-node" label="Typescript (Node.js)">
 
 ```js
 // Writing data to the channel as the channel owner.

--- a/iota/docs/integration-services/docs/how_tos/integration-services-sdk/create-channel.mdx
+++ b/iota/docs/integration-services/docs/how_tos/integration-services-sdk/create-channel.mdx
@@ -37,7 +37,7 @@ mvn exec:_java -Dexec.mainClass=net.gradbase.how_tos.CreateChannel
 **Example source code**: [Example-5](https://github.com/albydeca/iota-is-sdk/blob/main/examples/src/main/java/net/gradbase/examples/CreateChannel.java)
 
 </TabItem>
-<TabItem value="node" label="Node.js">
+<TabItem value="typescript-node" label="Typescript (Node.js)">
 
 ```bash
 npm run example-5
@@ -72,7 +72,7 @@ System.out.println(channelAddress);
 ```
 
 </TabItem>
-<TabItem value="node" label="Node.js">
+<TabItem value="typescript-node" label="Typescript (Node.js)">
 
 ```js
 // The owner creates a channel where he/she want to publish data of type 'example-data'.
@@ -101,7 +101,7 @@ for (int i = 0; i < 3; i++) {
 ```
 
 </TabItem>
-<TabItem value="node" label="Node.js">
+<TabItem value="typescript-node" label="Typescript (Node.js)">
 
 ```js
 await channel.write(channelAddress, {
@@ -132,7 +132,7 @@ for (ChannelData data : datas) {
 ```
 
 </TabItem>
-<TabItem value="node" label="Node.js">
+<TabItem value="typescript-node" label="Typescript (Node.js)">
 
 ```java
 const channelData = await channel.read(channelAddress);

--- a/iota/docs/integration-services/docs/how_tos/integration-services-sdk/create-identity-and-credentials.mdx
+++ b/iota/docs/integration-services/docs/how_tos/integration-services-sdk/create-identity-and-credentials.mdx
@@ -38,7 +38,7 @@ mvn exec:_java -Dexec.mainClass=net.gradbase.how_tos.CreateIdentityAndCredential
 **Example source code**: [Example-1](https://github.com/albydeca/iota-is-sdk/blob/main/examples/src/main/java/net/gradbase/examples/CreateIdentityAndCredential.java)
 
 </TabItem>
-<TabItem value="node" label="Node.js">
+<TabItem value="typescript-node" label="Typescript (Node.js)">
 
 ```bash
 npm run example-1
@@ -80,7 +80,7 @@ throw new Exception("admin identity has no credentials");
 ```
 
 </TabItem>
-<TabItem value="node" label="Node.js">
+<TabItem value="typescript-node" label="Typescript (Node.js)">
 
 ```js
 import { IdentityClient, IdentityKeys }  from '@iota/is-client';
@@ -143,7 +143,7 @@ System.out.println("Created credential for new user " + assignedCredential.toStr
 ```
 
 </TabItem>
-<TabItem value="node" label="Node.js">
+<TabItem value="typescript-node" label="Typescript (Node.js)">
 
 ```js
 // Create identity for user
@@ -181,7 +181,7 @@ System.out.println("Verification result: " + verified);
 ```
 
 </TabItem>
-<TabItem value="node" label="Node.js">
+<TabItem value="typescript-node" label="Typescript (Node.js)">
 
 ```js
 const verified = await identity.checkCredential(userCredential);

--- a/iota/docs/integration-services/docs/how_tos/integration-services-sdk/delete-users.mdx
+++ b/iota/docs/integration-services/docs/how_tos/integration-services-sdk/delete-users.mdx
@@ -39,7 +39,7 @@ mvn exec:_java -Dexec.mainClass=net.gradbase.how_tos.DeleteUser
 **Example source code**: [Example-3](https://github.com/albydeca/iota-is-sdk/blob/main/examples/src/main/java/net/gradbase/examples/DeleteUser.java)
 
 </TabItem>
-<TabItem value="node" label="Node.js">
+<TabItem value="typescript-node" label="Typescript (Node.js)">
 
 ```bash
 npm run example-3
@@ -63,7 +63,7 @@ identityClient.remove(someIdentity.getId(), true);
 ```
 
 </TabItem>
-<TabItem value="node" label="Node.js">
+<TabItem value="typescript-node" label="Typescript (Node.js)">
 
 ```js
 // Remove the user and also revoke the user's credentials
@@ -91,7 +91,7 @@ JSONObject recoveredIdentity = identityClient.latestDocument(someIdentity.getId(
 ```
 
 </TabItem>
-<TabItem value="node" label="Node.js">
+<TabItem value="typescript-node" label="Typescript (Node.js)">
 
 ```js
 const recoveredIdentity = await identity.latestDocument(userIdentity.id);

--- a/iota/docs/integration-services/docs/how_tos/integration-services-sdk/introduction.mdx
+++ b/iota/docs/integration-services/docs/how_tos/integration-services-sdk/introduction.mdx
@@ -49,7 +49,7 @@ or simply add to your POM:
 ```
 
 </TabItem>
-<TabItem value="node" label="Node.js">
+<TabItem value="typescript-node" label="Typescript (Node.js)">
 You can install the Integration Services Client using [npm](https://npmjs.com/) or [yarn](https://yarnpkg.com/).
 
 <Tabs groupId="language" queryString>
@@ -112,7 +112,7 @@ You can import and configure these clients using a `env.properties` object which
 ```
 
 </TabItem>
-<TabItem value="node" label="Node.js">
+<TabItem value="typescript-node" label="Typescript (Node.js)">
 
 You can import and configure these clients using a `ClientConfig` object:
 
@@ -171,7 +171,7 @@ You can get an identity using the following script (no auth required):
 ```
 
 </TabItem>
-    <TabItem value="node" label="Node.js">
+    <TabItem value="typescript-node" label="Typescript (Node.js)">
 
 ```js
 const identity = await identityClient.create('User');
@@ -216,7 +216,7 @@ If you have a JSON Identity, you can authorize your client as follows:
 ```
 
 </TabItem>
-<TabItem value="node" label="Node.js">
+<TabItem value="typescript-node" label="Typescript (Node.js)">
 
 ```js
 const identity = // ... did-core json object ...

--- a/iota/docs/integration-services/docs/how_tos/integration-services-sdk/run-how-tos.mdx
+++ b/iota/docs/integration-services/docs/how_tos/integration-services-sdk/run-how-tos.mdx
@@ -27,7 +27,7 @@ You can find many examples related to managing identities and channels in the Gi
 [Examples](https://github.com/albydeca/iota-is-sdk/tree/main/examples)
 
 </TabItem>
-<TabItem value="node" label="Node.js">
+<TabItem value="typescript-node" label="Typescript (Node.js)">
 
 [Examples](https://github.com/iotaledger/integration-services/tree/master/clients/client-sdk/examples)
 
@@ -51,7 +51,7 @@ The next sections will describe each example in detail.
 Alternatively, a basic [Dockerfile](https://github.com/albydeca/iota-is-sdk/blob/main/Dockerfile) has been provided that will allow you to run all the examples in one go.
 
 </TabItem>
-<TabItem value="node" label="Node.js">
+<TabItem value="typescript-node" label="Typescript (Node.js)">
 
 In order to run examples, you will need to:
 
@@ -91,7 +91,7 @@ identity-file=adminIdentity.json
 Please note the Java SDK assumes that an instance of the API, including its MongoDB connection, is already running elsewhere.
 
 </TabItem>
-<TabItem value="node" label="Node.js">
+<TabItem value="typescript-node" label="Typescript (Node.js)">
 
 1. Set Integration Service API's endpoint by setting the `API_KEY` and `API_URL` in `.env` file.
 2. Set the MongoDB endpoint for the API by setting `MONGO_URL`, `DB_NAME` and `SECRET_KEY` in `.env` file.
@@ -138,7 +138,7 @@ mvn exec:_java -Dexec.mainClass=net.gradbase.how_tos.AddAsRootIdentity
 ```
 
 </TabItem>
-<TabItem value="node" label="Node.js">
+<TabItem value="typescript-node" label="Typescript (Node.js)">
 
 Once you have completed the previous steps, you can run [example-0](https://github.com/iotaledger/integration-services/blob/master/clients/client-sdk/examples/0-MakeRootIdentityAdmin.ts) to create a decentralized identity with `Admin` role
 that will be used in the other examples using the following command:

--- a/iota/docs/integration-services/docs/how_tos/integration-services-sdk/search-channel-and-validate-data.mdx
+++ b/iota/docs/integration-services/docs/how_tos/integration-services-sdk/search-channel-and-validate-data.mdx
@@ -28,7 +28,7 @@ mvn exec:_java -Dexec.mainClass=net.gradbase.how_tos.SearchChannelAndValidateDat
 **Example source code**: [Example-7](https://github.com/albydeca/iota-is-sdk/blob/main/examples/src/main/java/net/gradbase/examples/SearchChannelAndValidateData.java)
 
 </TabItem>
-<TabItem value="node" label="Node.js">
+<TabItem value="typescript-node" label="Typescript (Node.js)">
 
 ```bash
 npm run example-7
@@ -52,7 +52,7 @@ JSONArray validated = userClient.validate(channelAddress, resuts);
 ```
 
 </TabItem>
-<TabItem value="node" label="Node.js">
+<TabItem value="typescript-node" label="Typescript (Node.js)">
 
 ```js
 // Now try to validate the manipulated data

--- a/iota/docs/integration-services/docs/how_tos/integration-services-sdk/trusted-authorities.mdx
+++ b/iota/docs/integration-services/docs/how_tos/integration-services-sdk/trusted-authorities.mdx
@@ -37,7 +37,7 @@ mvn exec:_java -Dexec.mainClass=net.gradbase.how_tos.TrustedAuthorities
 **Example source code**: [Example-7](https://github.com/albydeca/iota-is-sdk/blob/main/examples/src/main/java/net/gradbase/examples/TrustedAuthorities.java)
 
 </TabItem>
-<TabItem value="node" label="Node.js">
+<TabItem value="typescript-node" label="Typescript (Node.js)">
 
 ```bash
 npm run example-4
@@ -52,7 +52,7 @@ npm run example-4
 <TabItem value="java" label="Java">
 
 </TabItem>
-<TabItem value="node" label="Node.js">
+<TabItem value="typescript-node" label="Typescript (Node.js)">
 
 </TabItem>
 </Tabs>

--- a/iota/docs/integration-services/docs/how_tos/integration-services-sdk/update-users.mdx
+++ b/iota/docs/integration-services/docs/how_tos/integration-services-sdk/update-users.mdx
@@ -32,7 +32,7 @@ mvn exec:_java -Dexec.mainClass=net.gradbase.how_tos.UpdateUser
 **Example source code**: [Example-7](hhttps://github.com/albydeca/iota-is-sdk/blob/main/examples/src/main/java/net/gradbase/examples/UpdateUser.java)
 
 </TabItem>
-<TabItem value="node" label="Node.js">
+<TabItem value="typescript-node" label="Typescript (Node.js)">
 
 ```bash
 npm run example-2
@@ -56,7 +56,7 @@ List<IdentityInternal> identities = client.search(null, "User", null, null, null
 ```
 
 </TabItem>
-<TabItem value="node" label="Node.js">
+<TabItem value="typescript-node" label="Typescript (Node.js)">
 
 ```js
 // Search for identities with username 'User' in it

--- a/iota/docs/iota.rs/docs/examples/data_message.mdx
+++ b/iota/docs/iota.rs/docs/examples/data_message.mdx
@@ -32,7 +32,7 @@ and a key `index` to a message. To send a payload, you should at least provide t
   <TabItem value='java' label='Java'>
     <JavaDataMessage />
   </TabItem>
-  <TabItem value='node' label='Node.js'>
+  <TabItem value='typescript-node' label='Typescript (Node.js)'>
     <NodejsGetDataMessage />
   </TabItem>
   <TabItem value='python' label='Python'>
@@ -41,7 +41,7 @@ and a key `index` to a message. To send a payload, you should at least provide t
   <TabItem value='rust' label='Rust'>
     <RustGetDataMessage />
   </TabItem>
-  <TabItem value='wasm' label='Wasm'>
+  <TabItem value='typescript-wasm' label='Typescript (Wasm)'>
     <WasmGetDataMessage />
   </TabItem>
 </Tabs>

--- a/iota/docs/iota.rs/docs/examples/generate_addresses.mdx
+++ b/iota/docs/iota.rs/docs/examples/generate_addresses.mdx
@@ -31,7 +31,7 @@ import WasmGenerateAddresses from '../libraries/wasm/examples/_03_generate_addre
   <TabItem value='java' label='Java'>
     <JavaGenerateAddresses />
   </TabItem>
-  <TabItem value='node' label='Node.js'>
+  <TabItem value='typescript-node' label='Typescript (Node.js)'>
     <NodejsGenerateAddresses />
   </TabItem>
   <TabItem value='python' label='Python'>
@@ -40,7 +40,7 @@ import WasmGenerateAddresses from '../libraries/wasm/examples/_03_generate_addre
   <TabItem value='rust' label='Rust'>
     <RustGenerateAddresses />
   </TabItem>
-  <TabItem value='wasm' label='Wasm'>
+  <TabItem value='typescript-wasm' label='Typescript (Wasm)'>
     <WasmGenerateAddresses />
   </TabItem>
 </Tabs>

--- a/iota/docs/iota.rs/docs/examples/generate_seed.mdx
+++ b/iota/docs/iota.rs/docs/examples/generate_seed.mdx
@@ -36,7 +36,7 @@ import WasmGenerateSeed from '../libraries/wasm/examples/_02_generate_seed.mdx';
   <TabItem value='java' label='Java'>
     <JavaGenerateSeed />
   </TabItem>
-  <TabItem value='node' label='Node.js'>
+  <TabItem value='typescript-node' label='Typescript (Node.js)'>
     <NodejsGenerateSeed />
   </TabItem>
   <TabItem value='python' label='Python'>
@@ -45,7 +45,7 @@ import WasmGenerateSeed from '../libraries/wasm/examples/_02_generate_seed.mdx';
   <TabItem value='rust' label='Rust'>
     <RustGenerateSeed />
   </TabItem>
-  <TabItem value='wasm' label='Wasm'>
+  <TabItem value='typescript-wasm' label='Typescript (Wasm)'>
     <WasmGenerateSeed />
   </TabItem>
 </Tabs>

--- a/iota/docs/iota.rs/docs/examples/get_balance.mdx
+++ b/iota/docs/iota.rs/docs/examples/get_balance.mdx
@@ -31,7 +31,7 @@ import WasmGetBalance from '../libraries/wasm/examples/_04_get_balance.mdx';
   <TabItem value='java' label='Java'>
     <JavaGetBalance />
   </TabItem>
-  <TabItem value='node' label='Node.js'>
+  <TabItem value='typescript-node' label='Typescript (Node.js)'>
     <NodejsGetBalance />
   </TabItem>
   <TabItem value='python' label='Python'>
@@ -40,7 +40,7 @@ import WasmGetBalance from '../libraries/wasm/examples/_04_get_balance.mdx';
   <TabItem value='rust' label='Rust'>
     <RustGetBalance />
   </TabItem>
-  <TabItem value='wasm' label='Wasm'>
+  <TabItem value='typescript-wasm' label='Typescript (Wasm)'>
     <WasmGetBalance />
   </TabItem>
 </Tabs>

--- a/iota/docs/iota.rs/docs/examples/get_info.mdx
+++ b/iota/docs/iota.rs/docs/examples/get_info.mdx
@@ -41,7 +41,7 @@ participate in: [`devnet`](https://wiki.iota.org/introduction/reference/networks
   <TabItem value='java' label='Java'>
     <JavaGetInfo />
   </TabItem>
-  <TabItem value='node' label='Node.js'>
+  <TabItem value='typescript-node' label='Typescript (Node.js)'>
     <NodejsGetInfo />
   </TabItem>
   <TabItem value='python' label='Python'>
@@ -50,7 +50,7 @@ participate in: [`devnet`](https://wiki.iota.org/introduction/reference/networks
   <TabItem value='rust' label='Rust'>
     <RustGetInfo />
   </TabItem>
-  <TabItem value='wasm' label='Wasm'>
+  <TabItem value='typescript-wasm' label='Typescript (Wasm)'>
     <WasmGetInfo />
   </TabItem>
 </Tabs>

--- a/iota/docs/iota.rs/docs/examples/get_message_data.mdx
+++ b/iota/docs/iota.rs/docs/examples/get_message_data.mdx
@@ -26,7 +26,7 @@ import WasmGetMessageData from '../libraries/wasm/examples/_07_get_message_data.
   <TabItem value='java' label='Java'>
     <JavaGetMessageData />
   </TabItem>
-  <TabItem value='node' label='Node.js'>
+  <TabItem value='typescript-node' label='Typescript (Node.js)'>
     <NodejsGetMessageData />
   </TabItem>
   <TabItem value='python' label='Python'>
@@ -35,7 +35,7 @@ import WasmGetMessageData from '../libraries/wasm/examples/_07_get_message_data.
   <TabItem value='rust' label='Rust'>
     <RustGetMessageData />
   </TabItem>
-  <TabItem value='wasm' label='Wasm'>
+  <TabItem value='typescript-wasm' label='Typescript (Wasm)'>
     <WasmGetMessageData />
   </TabItem>
 </Tabs>

--- a/iota/docs/iota.rs/docs/examples/get_outputs.mdx
+++ b/iota/docs/iota.rs/docs/examples/get_outputs.mdx
@@ -35,7 +35,7 @@ outputs related an address.
   <TabItem value='java' label='Java'>
     <JavaGetOutputs />
   </TabItem>
-  <TabItem value='node' label='Node.js'>
+  <TabItem value='typescript-node' label='Typescript (Node.js)'>
     <NodejsGetOutputs />
   </TabItem>
   <TabItem value='python' label='Python'>
@@ -44,7 +44,7 @@ outputs related an address.
   <TabItem value='rust' label='Rust'>
     <RustGetOutputs />
   </TabItem>
-  <TabItem value='wasm' label='Wasm'>
+  <TabItem value='typescript-wasm' label='Typescript (Wasm)'>
     <WasmGetOutputs />
   </TabItem>
 </Tabs>

--- a/iota/docs/iota.rs/docs/examples/mqtt.mdx
+++ b/iota/docs/iota.rs/docs/examples/mqtt.mdx
@@ -51,7 +51,7 @@ MQTT events based on a `topic`, which can be:
   <TabItem value='java' label='Java'>
     <Javamqtt />
   </TabItem>
-  <TabItem value='node' label='Node.js'>
+  <TabItem value='typescript-node' label='Typescript (Node.js)'>
     <Nodejsmqtt />
   </TabItem>
   <TabItem value='python' label='Python'>

--- a/iota/docs/iota.rs/docs/examples/running_examples.mdx
+++ b/iota/docs/iota.rs/docs/examples/running_examples.mdx
@@ -32,7 +32,7 @@ import WarningPasswordStorage from '../_admonitions/_password_storage.md';
   <TabItem value='java' label='Java'>
     <JavaRunningExamples />
   </TabItem>
-  <TabItem value='node' label='Node.js'>
+  <TabItem value='typescript-node' label='Typescript (Node.js)'>
     <NodejsRunningExamples />
   </TabItem>
   <TabItem value='python' label='Python'>
@@ -41,7 +41,7 @@ import WarningPasswordStorage from '../_admonitions/_password_storage.md';
   <TabItem value='rust' label='Rust'>
     <RustRunningExamples />
   </TabItem>
-  <TabItem value='wasm' label='Wasm'>
+  <TabItem value='typescript-wasm' label='Typescript (Wasm)'>
     <WasmRunningExamples />
   </TabItem>
 </Tabs>

--- a/iota/docs/iota.rs/docs/examples/simple_message.mdx
+++ b/iota/docs/iota.rs/docs/examples/simple_message.mdx
@@ -32,7 +32,7 @@ The simplest message you can broadcast is a message without any particular paylo
   <TabItem value='java' label='Java'>
     <JavaSimpleMessage />
   </TabItem>
-  <TabItem value='node' label='Node.js'>
+  <TabItem value='typescript-node' label='Typescript (Node.js)'>
     <NodejsSimpleMessage />
   </TabItem>
   <TabItem value='python' label='Python'>
@@ -41,7 +41,7 @@ The simplest message you can broadcast is a message without any particular paylo
   <TabItem value='rust' label='Rust'>
     <RustSimpleMessage />
   </TabItem>
-  <TabItem value='wasm' label='Wasm'>
+  <TabItem value='typescript-wasm' label='Typescript (Wasm)'>
     <WasmSimpleMessage />
   </TabItem>
 </Tabs>

--- a/iota/docs/iota.rs/docs/examples/transaction.mdx
+++ b/iota/docs/iota.rs/docs/examples/transaction.mdx
@@ -37,7 +37,7 @@ This core payload changes the ledger state as it spends "old" outputs and replac
   <TabItem value='java' label='Java'>
     <JavaTransaction />
   </TabItem>
-  <TabItem value='node' label='Node.js'>
+  <TabItem value='typescript-node' label='Typescript (Node.js)'>
     <NodejsGetTransaction />
   </TabItem>
   <TabItem value='python' label='Python'>
@@ -46,7 +46,7 @@ This core payload changes the ledger state as it spends "old" outputs and replac
   <TabItem value='rust' label='Rust'>
     <RustGetTransaction />
   </TabItem>
-  <TabItem value='wasm' label='Wasm'>
+  <TabItem value='typescript-wasm' label='Typescript (Wasm)'>
     <WasmGetTransaction />
   </TabItem>
 </Tabs>

--- a/next/docs/identity.rs/0.7-alpha/docs/concepts/decentralized_identifiers/create.mdx
+++ b/next/docs/identity.rs/0.7-alpha/docs/concepts/decentralized_identifiers/create.mdx
@@ -26,7 +26,7 @@ https://github.com/iotaledger/identity.rs/blob/main/examples/0_basic/0_create_di
 ```
 
 </TabItem>
-<TabItem value="node" label="Node.js">
+<TabItem value="typescript-node" label="Typescript (Node.js)">
 
 ```ts reference
 https://github.com/iotaledger/identity.rs/blob/main/bindings/wasm/examples/src/0_basic/0_create_did.ts

--- a/next/docs/identity.rs/0.7-alpha/docs/concepts/decentralized_identifiers/delete.mdx
+++ b/next/docs/identity.rs/0.7-alpha/docs/concepts/decentralized_identifiers/delete.mdx
@@ -42,7 +42,7 @@ https://github.com/iotaledger/identity.rs/blob/main/examples/0_basic/3_deactivat
 ```
 
 </TabItem>
-<TabItem value="node" label="Node.js">
+<TabItem value="typescript-node" label="Typescript (Node.js)">
 
 ```ts reference
 https://github.com/iotaledger/identity.rs/blob/main/bindings/wasm/examples/src/0_basic/3_deactivate_did.ts
@@ -79,7 +79,7 @@ https://github.com/iotaledger/identity.rs/blob/main/examples/0_basic/4_delete_di
 ```
 
 </TabItem>
-<TabItem value="node" label="Node.js">
+<TabItem value="typescript-node" label="Typescript (Node.js)">
 
 ```ts reference
 https://github.com/iotaledger/identity.rs/blob/main/bindings/wasm/examples/src/0_basic/4_delete_did.ts

--- a/next/docs/identity.rs/0.7-alpha/docs/concepts/decentralized_identifiers/resolve.mdx
+++ b/next/docs/identity.rs/0.7-alpha/docs/concepts/decentralized_identifiers/resolve.mdx
@@ -58,7 +58,7 @@ async fn main() -> anyhow::Result<()>{
 ```
 
 </TabItem>
-<TabItem value="node" label="Node.js">
+<TabItem value="typescript-node" label="Typescript (Node.js)">
 
 ```js
 const {
@@ -119,7 +119,7 @@ async fn main() -> anyhow::Result<()>{
 ```
 
 </TabItem>
-<TabItem value="node" label="Node.js">
+<TabItem value="typescript-node" label="Typescript (Node.js)">
 
 ```js
 const { IotaDID, IotaIdentityClient } = require('@iota/identity-wasm/node');
@@ -158,7 +158,7 @@ https://github.com/iotaledger/identity.rs/blob/main/examples/1_advanced/5_custom
 ```
 
 </TabItem>
-<TabItem value="node" label="Node.js">
+<TabItem value="typescript-node" label="Typescript (Node.js)">
 
 ```ts reference
 https://github.com/iotaledger/identity.rs/blob/main/bindings/wasm/examples/src/1_advanced/4_custom_resolution.ts

--- a/next/docs/identity.rs/0.7-alpha/docs/concepts/decentralized_identifiers/update.mdx
+++ b/next/docs/identity.rs/0.7-alpha/docs/concepts/decentralized_identifiers/update.mdx
@@ -75,7 +75,7 @@ https://github.com/iotaledger/identity.rs/blob/main/examples/0_basic/1_update_di
 ```
 
 </TabItem>
-<TabItem value="node" label="Node.js">
+<TabItem value="typescript-node" label="Typescript (Node.js)">
 
 ```ts reference
 https://github.com/iotaledger/identity.rs/blob/main/bindings/wasm/examples/src/0_basic/1_update_did.ts
@@ -108,7 +108,7 @@ let (_, did): (Address, StardustDID) = create_did(&client, &mut secret_manager).
 ```
 
 </TabItem>
-<TabItem value="node" label="Node.js">
+<TabItem value="typescript-node" label="Typescript (Node.js)">
 
 ```js
 const { didClient, secretManager, did } = await createIdentity();
@@ -153,7 +153,7 @@ This creates and publishes an Alias Output containing a DID Document with one ve
 ```
 
 </TabItem>
-<TabItem value="node" label="Node.js">
+<TabItem value="typescript-node" label="Typescript (Node.js)">
 
 ```js
 // Insert a new Ed25519 verification method in the DID document.
@@ -216,7 +216,7 @@ document.attach_method_relationship(
 ```
 
 </TabItem>
-<TabItem value="node" label="Node.js">
+<TabItem value="typescript-node" label="Typescript (Node.js)">
 
 ```js
 // Attach a new method relationship to the existing method.
@@ -277,7 +277,7 @@ document.metadata.updated = Some(Timestamp::now_utc());
 ```
 
 </TabItem>
-<TabItem value="node" label="Node.js">
+<TabItem value="typescript-node" label="Typescript (Node.js)">
 
 ```js
 // Add a new Service.
@@ -345,7 +345,7 @@ document.remove_method(&original_method).unwrap();
 ```
 
 </TabItem>
-<TabItem value="node" label="Node.js">
+<TabItem value="typescript-node" label="Typescript (Node.js)">
 
 ```js
 // Remove a verification method.
@@ -411,7 +411,7 @@ let updated: StardustDocument = client.publish_did_output(&secret_manager, alias
 ```
 
 </TabItem>
-<TabItem value="node" label="Node.js">
+<TabItem value="typescript-node" label="Typescript (Node.js)">
 
 ```js
 // Resolve the latest output and update it with the given document.

--- a/next/docs/identity.rs/0.7-alpha/docs/concepts/domain_linkage/domain_linkage.mdx
+++ b/next/docs/identity.rs/0.7-alpha/docs/concepts/domain_linkage/domain_linkage.mdx
@@ -137,7 +137,7 @@ https://github.com/iotaledger/identity.rs/blob/main/examples/1_advanced/6_domain
 ```
 
 </TabItem>
-<TabItem value="node" label="Node.js">
+<TabItem value="typescript-node" label="Typescript (Node.js)">
 
 ```ts reference
 https://github.com/iotaledger/identity.rs/blob/main/bindings/wasm/examples/src/1_advanced/5_domain_linkage.ts

--- a/next/docs/identity.rs/0.7-alpha/docs/concepts/verifiable_credentials/create.mdx
+++ b/next/docs/identity.rs/0.7-alpha/docs/concepts/verifiable_credentials/create.mdx
@@ -91,7 +91,7 @@ https://github.com/iotaledger/identity.rs/blob/main/examples/0_basic/5_create_vc
 ```
 
 </TabItem>
-<TabItem value="node" label="Node.js">
+<TabItem value="typescript-node" label="Typescript (Node.js)">
 
 ```ts reference
 https://github.com/iotaledger/identity.rs/blob/main/bindings/wasm/examples/src/0_basic/5_create_vc.ts

--- a/next/docs/identity.rs/0.7-alpha/docs/concepts/verifiable_credentials/revocation.mdx
+++ b/next/docs/identity.rs/0.7-alpha/docs/concepts/verifiable_credentials/revocation.mdx
@@ -62,7 +62,7 @@ https://github.com/iotaledger/identity.rs/blob/main/examples/0_basic/7_revoke_vc
 ```
 
 </TabItem>
-<TabItem value="node" label="Node.js">
+<TabItem value="typescript-node" label="Typescript (Node.js)">
 
 ```ts reference
 https://github.com/iotaledger/identity.rs/blob/main/bindings/wasm/examples/src/0_basic/7_revoke_vc.ts

--- a/next/docs/identity.rs/0.7-alpha/docs/concepts/verifiable_credentials/verifiable_presentations.mdx
+++ b/next/docs/identity.rs/0.7-alpha/docs/concepts/verifiable_credentials/verifiable_presentations.mdx
@@ -174,7 +174,7 @@ https://github.com/iotaledger/identity.rs/blob/main/examples/0_basic/6_create_vp
 ```
 
 </TabItem>
-<TabItem value="node" label="Node.js">
+<TabItem value="typescript-node" label="Typescript (Node.js)">
 
 ```ts reference
 https://github.com/iotaledger/identity.rs/blob/main/bindings/wasm/examples/src/0_basic/6_create_vp.ts

--- a/next/docs/identity.rs/0.7-alpha/docs/getting_started/create_and_publish.mdx
+++ b/next/docs/identity.rs/0.7-alpha/docs/getting_started/create_and_publish.mdx
@@ -36,7 +36,7 @@ https://github.com/iotaledger/identity.rs/blob/main/examples/0_basic/0_create_di
 ```
 
 </TabItem>
-<TabItem value="node" label="Node.js">
+<TabItem value="typescript-node" label="Typescript (Node.js)">
 
 ```ts reference
 https://github.com/iotaledger/identity.rs/blob/main/bindings/wasm/examples/src/0_basic/0_create_did.ts

--- a/next/docs/iota-sdk/docs/how-tos/accounts-and-addresses/check-balance.mdx
+++ b/next/docs/iota-sdk/docs/how-tos/accounts-and-addresses/check-balance.mdx
@@ -40,7 +40,7 @@ https://github.com/iotaledger/iota-sdk/blob/develop/sdk/examples/how_tos/account
 ```
 
 </TabItem>
-<TabItem value="node" label="Node.js">
+<TabItem value="typescript-node" label="Typescript (Node.js)">
 
 ```typescript reference
 https://github.com/iotaledger/iota-sdk/blob/develop/bindings/nodejs/examples/how_tos/accounts_and_addresses/check-balance.ts
@@ -82,7 +82,7 @@ Balance {
 ```
 
 </TabItem>
-<TabItem value="node" label="Node.js">
+<TabItem value="typescript-node" label="Typescript (Node.js)">
 
 ```plaintext
 Balance {

--- a/next/docs/iota-sdk/docs/how-tos/accounts-and-addresses/consolidate-outputs.mdx
+++ b/next/docs/iota-sdk/docs/how-tos/accounts-and-addresses/consolidate-outputs.mdx
@@ -25,7 +25,7 @@ https://github.com/iotaledger/iota-sdk/blob/develop/sdk/examples/how_tos/account
 ```
 
 </TabItem>
-<TabItem value="node" label="Node.js">
+<TabItem value="typescript-node" label="Typescript (Node.js)">
 
 ```typescript reference
 https://github.com/iotaledger/iota-sdk/blob/develop/bindings/nodejs/examples/how_tos/accounts_and_addresses/consolidate-outputs.ts
@@ -73,7 +73,7 @@ OUTPUT #0
 ```
 
 </TabItem>
-<TabItem value="node" label="Node.js">
+<TabItem value="typescript-node" label="Typescript (Node.js)">
 
 ```plaintext
 Account synced

--- a/next/docs/iota-sdk/docs/how-tos/accounts-and-addresses/create-account.mdx
+++ b/next/docs/iota-sdk/docs/how-tos/accounts-and-addresses/create-account.mdx
@@ -38,7 +38,7 @@ https://github.com/iotaledger/iota-sdk/blob/develop/sdk/examples/how_tos/account
 ```
 
 </TabItem>
-<TabItem value="node" label="Node.js">
+<TabItem value="typescript-node" label="Typescript (Node.js)">
 
 ```typescript reference
 https://github.com/iotaledger/iota-sdk/blob/develop/bindings/nodejs/examples/how_tos/accounts_and_addresses/create-account.ts

--- a/next/docs/iota-sdk/docs/how-tos/accounts-and-addresses/create-address.mdx
+++ b/next/docs/iota-sdk/docs/how-tos/accounts-and-addresses/create-address.mdx
@@ -38,7 +38,7 @@ https://github.com/iotaledger/iota-sdk/blob/develop/sdk/examples/how_tos/account
 ```
 
 </TabItem>
-<TabItem value="node" label="Node.js">
+<TabItem value="typescript-node" label="Typescript (Node.js)">
 
 ```typescript reference
 https://github.com/iotaledger/iota-sdk/blob/develop/bindings/nodejs/examples/how_tos/accounts_and_addresses/create-address.ts

--- a/next/docs/iota-sdk/docs/how-tos/accounts-and-addresses/create-mnemonic.mdx
+++ b/next/docs/iota-sdk/docs/how-tos/accounts-and-addresses/create-mnemonic.mdx
@@ -26,7 +26,7 @@ https://github.com/iotaledger/iota-sdk/blob/develop/sdk/examples/how_tos/account
 ```
 
 </TabItem>
-<TabItem value="node" label="Node.js">
+<TabItem value="typescript-node" label="Typescript (Node.js)">
 
 ```typescript reference
 https://github.com/iotaledger/iota-sdk/blob/develop/bindings/nodejs/examples/how_tos/accounts_and_addresses/create-mnemonic.ts

--- a/next/docs/iota-sdk/docs/how-tos/accounts-and-addresses/list-accounts.mdx
+++ b/next/docs/iota-sdk/docs/how-tos/accounts-and-addresses/list-accounts.mdx
@@ -28,7 +28,7 @@ https://github.com/iotaledger/iota-sdk/blob/develop/sdk/examples/how_tos/account
 ```
 
 </TabItem>
-<TabItem value="node" label="Node.js">
+<TabItem value="typescript-node" label="Typescript (Node.js)">
 
 ```typescript reference
 https://github.com/iotaledger/iota-sdk/blob/develop/bindings/nodejs/examples/how_tos/accounts_and_addresses/list-accounts.ts

--- a/next/docs/iota-sdk/docs/how-tos/accounts-and-addresses/list-addresses.mdx
+++ b/next/docs/iota-sdk/docs/how-tos/accounts-and-addresses/list-addresses.mdx
@@ -26,7 +26,7 @@ https://github.com/iotaledger/iota-sdk/blob/develop/sdk/examples/how_tos/account
 ```
 
 </TabItem>
-<TabItem value="node" label="Node.js">
+<TabItem value="typescript-node" label="Typescript (Node.js)">
 
 ```typescript reference
 https://github.com/iotaledger/iota-sdk/blob/develop/bindings/nodejs/examples/how_tos/accounts_and_addresses/list-addresses.ts

--- a/next/docs/iota-sdk/docs/how-tos/accounts-and-addresses/list-outputs.mdx
+++ b/next/docs/iota-sdk/docs/how-tos/accounts-and-addresses/list-outputs.mdx
@@ -25,7 +25,7 @@ https://github.com/iotaledger/iota-sdk/blob/develop/sdk/examples/how_tos/account
 ```
 
 </TabItem>
-<TabItem value="node" label="Node.js">
+<TabItem value="typescript-node" label="Typescript (Node.js)">
 
 ```typescript reference
 https://github.com/iotaledger/iota-sdk/blob/develop/bindings/nodejs/examples/how_tos/accounts_and_addresses/list-outputs.ts

--- a/next/docs/iota-sdk/docs/how-tos/accounts-and-addresses/list-transactions.mdx
+++ b/next/docs/iota-sdk/docs/how-tos/accounts-and-addresses/list-transactions.mdx
@@ -33,7 +33,7 @@ https://github.com/iotaledger/iota-sdk/blob/develop/sdk/examples/how_tos/account
 ```
 
 </TabItem>
-<TabItem value="node" label="Node.js">
+<TabItem value="typescript-node" label="Typescript (Node.js)">
 
 ```typescript reference
 https://github.com/iotaledger/iota-sdk/blob/develop/bindings/nodejs/examples/how_tos/accounts_and_addresses/list-transactions.ts

--- a/next/docs/iota-sdk/docs/how-tos/advanced-transactions/advanced-transaction.mdx
+++ b/next/docs/iota-sdk/docs/how-tos/advanced-transactions/advanced-transaction.mdx
@@ -30,7 +30,7 @@ https://github.com/iotaledger/iota-sdk/blob/develop/sdk/examples/how_tos/advance
 ```
 
 </TabItem>
-<TabItem value="node" label="Node.js">
+<TabItem value="typescript-node" label="Typescript (Node.js)">
 
 ```typescript reference
 https://github.com/iotaledger/iota-sdk/blob/develop/bindings/nodejs/examples/how_tos/advanced_transactions/advanced_transaction.ts

--- a/next/docs/iota-sdk/docs/how-tos/advanced-transactions/claim-transaction.mdx
+++ b/next/docs/iota-sdk/docs/how-tos/advanced-transactions/claim-transaction.mdx
@@ -28,7 +28,7 @@ https://github.com/iotaledger/iota-sdk/blob/develop/sdk/examples/how_tos/advance
 ```
 
 </TabItem>
-<TabItem value="node" label="Node.js">
+<TabItem value="typescript-node" label="Typescript (Node.js)">
 
 ```typescript reference
 https://github.com/iotaledger/iota-sdk/blob/develop/bindings/nodejs/examples/how_tos/advanced_transactions/claim_transaction.ts

--- a/next/docs/iota-sdk/docs/how-tos/advanced-transactions/send-micro-transaction.mdx
+++ b/next/docs/iota-sdk/docs/how-tos/advanced-transactions/send-micro-transaction.mdx
@@ -38,7 +38,7 @@ https://github.com/iotaledger/iota-sdk/blob/develop/sdk/examples/how_tos/advance
 ```
 
 </TabItem>
-<TabItem value="node" label="Node.js">
+<TabItem value="typescript-node" label="Typescript (Node.js)">
 
 ```typescript reference
 https://github.com/iotaledger/iota-sdk/blob/develop/bindings/nodejs/examples/how_tos/advanced_transactions/send_micro_transaction.ts

--- a/next/docs/iota-sdk/docs/how-tos/alias-wallet/request-funds.mdx
+++ b/next/docs/iota-sdk/docs/how-tos/alias-wallet/request-funds.mdx
@@ -41,7 +41,7 @@ https://github.com/iotaledger/iota-sdk/blob/develop/sdk/examples/how_tos/alias_w
 ```
 
 </TabItem>
-<TabItem value="node" label="Node.js">
+<TabItem value="typescript-node" label="Typescript (Node.js)">
 
 ```typescript reference
 https://github.com/iotaledger/iota-sdk/blob/develop/bindings/nodejs/examples/how_tos/alias_wallet/request-funds.ts

--- a/next/docs/iota-sdk/docs/how-tos/alias-wallet/transaction.mdx
+++ b/next/docs/iota-sdk/docs/how-tos/alias-wallet/transaction.mdx
@@ -42,7 +42,7 @@ https://github.com/iotaledger/iota-sdk/blob/develop/sdk/examples/how_tos/alias_w
 ```
 
 </TabItem>
-<TabItem value="node" label="Node.js">
+<TabItem value="typescript-node" label="Typescript (Node.js)">
 
 ```typescript reference
 https://github.com/iotaledger/iota-sdk/blob/develop/bindings/nodejs/examples/how_tos/alias_wallet/transaction.ts

--- a/next/docs/iota-sdk/docs/how-tos/client/get-health.md
+++ b/next/docs/iota-sdk/docs/how-tos/client/get-health.md
@@ -36,7 +36,7 @@ https://github.com/iotaledger/iota-sdk/blob/develop/sdk/examples/how_tos/client/
 ```
 
 </TabItem>
-<TabItem value="node" label="Node.js">
+<TabItem value="typescript-node" label="Typescript (Node.js)">
 
 ```typescript reference
 https://github.com/iotaledger/iota-sdk/blob/develop/bindings/nodejs/examples/how_tos/client/get-health.ts

--- a/next/docs/iota-sdk/docs/how-tos/client/get-info.md
+++ b/next/docs/iota-sdk/docs/how-tos/client/get-info.md
@@ -36,7 +36,7 @@ https://github.com/iotaledger/iota-sdk/blob/develop/sdk/examples/how_tos/client/
 ```
 
 </TabItem>
-<TabItem value="node" label="Node.js">
+<TabItem value="typescript-node" label="Typescript (Node.js)">
 
 ```typescript reference
 https://github.com/iotaledger/iota-sdk/blob/develop/bindings/nodejs/examples/how_tos/client/get-info.ts
@@ -110,7 +110,7 @@ https://github.com/iotaledger/iota-sdk/blob/develop/bindings/python/examples/how
 ```
 
 </TabItem>
-<TabItem value="node" label="Node.js">
+<TabItem value="typescript-node" label="Typescript (Node.js)">
 
 ```bash
 {

--- a/next/docs/iota-sdk/docs/how-tos/client/get-outputs.md
+++ b/next/docs/iota-sdk/docs/how-tos/client/get-outputs.md
@@ -35,7 +35,7 @@ https://github.com/iotaledger/iota-sdk/blob/develop/sdk/examples/how_tos/client/
 ```
 
 </TabItem>
-<TabItem value="node" label="Node.js">
+<TabItem value="typescript-node" label="Typescript (Node.js)">
 
 ```typescript reference
 https://github.com/iotaledger/iota-sdk/blob/develop/bindings/nodejs/examples/how_tos/client/get-outputs.ts
@@ -91,7 +91,7 @@ OutputWithMetadata {
 ```
 
 </TabItem>
-<TabItem value="node" label="Node.js">
+<TabItem value="typescript-node" label="Typescript (Node.js)">
 
 ```bash
 First output of query:

--- a/next/docs/iota-sdk/docs/how-tos/native-tokens/burn.mdx
+++ b/next/docs/iota-sdk/docs/how-tos/native-tokens/burn.mdx
@@ -39,7 +39,7 @@ https://github.com/iotaledger/iota-sdk/blob/develop/sdk/examples/how_tos/native_
 ```
 
 </TabItem>
-<TabItem value="node" label="Node.js">
+<TabItem value="typescript-node" label="Typescript (Node.js)">
 
 ```typescript reference
 https://github.com/iotaledger/iota-sdk/blob/develop/bindings/nodejs/examples/how_tos/native_tokens/burn.ts

--- a/next/docs/iota-sdk/docs/how-tos/native-tokens/create.mdx
+++ b/next/docs/iota-sdk/docs/how-tos/native-tokens/create.mdx
@@ -39,7 +39,7 @@ https://github.com/iotaledger/iota-sdk/blob/develop/sdk/examples/how_tos/native_
 ```
 
 </TabItem>
-<TabItem value="node" label="Node.js">
+<TabItem value="typescript-node" label="Typescript (Node.js)">
 
 ```typescript reference
 https://github.com/iotaledger/iota-sdk/blob/develop/bindings/nodejs/examples/how_tos/native_tokens/create.ts

--- a/next/docs/iota-sdk/docs/how-tos/native-tokens/destroy-foundry.mdx
+++ b/next/docs/iota-sdk/docs/how-tos/native-tokens/destroy-foundry.mdx
@@ -45,7 +45,7 @@ https://github.com/iotaledger/iota-sdk/blob/develop/sdk/examples/how_tos/native_
 ```
 
 </TabItem>
-<TabItem value="node" label="Node.js">
+<TabItem value="typescript-node" label="Typescript (Node.js)">
 
 ```typescript reference
 https://github.com/iotaledger/iota-sdk/blob/develop/bindings/nodejs/examples/how_tos/native_tokens/destroy-foundry.ts

--- a/next/docs/iota-sdk/docs/how-tos/native-tokens/melt.mdx
+++ b/next/docs/iota-sdk/docs/how-tos/native-tokens/melt.mdx
@@ -38,7 +38,7 @@ https://github.com/iotaledger/iota-sdk/blob/develop/sdk/examples/how_tos/native_
 ```
 
 </TabItem>
-<TabItem value="node" label="Node.js">
+<TabItem value="typescript-node" label="Typescript (Node.js)">
 
 ```typescript reference
 https://github.com/iotaledger/iota-sdk/blob/develop/bindings/nodejs/examples/how_tos/native_tokens/melt.ts

--- a/next/docs/iota-sdk/docs/how-tos/native-tokens/mint.mdx
+++ b/next/docs/iota-sdk/docs/how-tos/native-tokens/mint.mdx
@@ -36,7 +36,7 @@ https://github.com/iotaledger/iota-sdk/blob/develop/sdk/examples/how_tos/native_
 ```
 
 </TabItem>
-<TabItem value="node" label="Node.js">
+<TabItem value="typescript-node" label="Typescript (Node.js)">
 
 ```typescript reference
 https://github.com/iotaledger/iota-sdk/blob/develop/bindings/nodejs/examples/how_tos/native_tokens/mint.ts

--- a/next/docs/iota-sdk/docs/how-tos/native-tokens/send.mdx
+++ b/next/docs/iota-sdk/docs/how-tos/native-tokens/send.mdx
@@ -41,7 +41,7 @@ https://github.com/iotaledger/iota-sdk/blob/develop/sdk/examples/how_tos/native_
 ```
 
 </TabItem>
-<TabItem value="node" label="Node.js">
+<TabItem value="typescript-node" label="Typescript (Node.js)">
 
 ```typescript reference
 https://github.com/iotaledger/iota-sdk/blob/develop/bindings/nodejs/examples/how_tos/native_tokens/send.ts

--- a/next/docs/iota-sdk/docs/how-tos/nfts/burn-nft.mdx
+++ b/next/docs/iota-sdk/docs/how-tos/nfts/burn-nft.mdx
@@ -26,7 +26,7 @@ https://github.com/iotaledger/iota-sdk/blob/develop/sdk/examples/how_tos/nfts/bu
 ```
 
 </TabItem>
-<TabItem value="node" label="Node.js">
+<TabItem value="typescript-node" label="Typescript (Node.js)">
 
 ```typescript reference
 https://github.com/iotaledger/iota-sdk/blob/develop/bindings/nodejs/examples/how_tos/nfts/burn_nft.ts

--- a/next/docs/iota-sdk/docs/how-tos/nfts/mint-nft.mdx
+++ b/next/docs/iota-sdk/docs/how-tos/nfts/mint-nft.mdx
@@ -26,7 +26,7 @@ https://github.com/iotaledger/iota-sdk/blob/develop/sdk/examples/how_tos/nfts/mi
 ```
 
 </TabItem>
-<TabItem value="node" label="Node.js">
+<TabItem value="typescript-node" label="Typescript (Node.js)">
 
 ```typescript reference
 https://github.com/iotaledger/iota-sdk/blob/develop/bindings/nodejs/examples/how_tos/nfts/mint_nft.ts

--- a/next/docs/iota-sdk/docs/how-tos/nfts/send-nft.mdx
+++ b/next/docs/iota-sdk/docs/how-tos/nfts/send-nft.mdx
@@ -26,7 +26,7 @@ https://github.com/iotaledger/iota-sdk/blob/develop/sdk/examples/how_tos/nfts/se
 ```
 
 </TabItem>
-<TabItem value="node" label="Node.js">
+<TabItem value="typescript-node" label="Typescript (Node.js)">
 
 ```typescript reference
 https://github.com/iotaledger/iota-sdk/blob/develop/bindings/nodejs/examples/how_tos/nfts/send_nft.ts

--- a/next/docs/iota-sdk/docs/how-tos/outputs/features.mdx
+++ b/next/docs/iota-sdk/docs/how-tos/outputs/features.mdx
@@ -46,7 +46,7 @@ https://github.com/iotaledger/iota-sdk/blob/develop/sdk/examples/how_tos/outputs
 ```
 
 </TabItem>
-<TabItem value="node" label="Node.js">
+<TabItem value="typescript-node" label="Typescript (Node.js)">
 
 ```typescript reference
 https://github.com/iotaledger/iota-sdk/blob/develop/bindings/nodejs/examples/how_tos/outputs/features.ts

--- a/next/docs/iota-sdk/docs/how-tos/outputs/unlock-conditions.mdx
+++ b/next/docs/iota-sdk/docs/how-tos/outputs/unlock-conditions.mdx
@@ -46,7 +46,7 @@ https://github.com/iotaledger/iota-sdk/blob/develop/sdk/examples/how_tos/outputs
 ```
 
 </TabItem>
-<TabItem value="node" label="Node.js">
+<TabItem value="typescript-node" label="Typescript (Node.js)">
 
 ```typescript reference
 https://github.com/iotaledger/iota-sdk/blob/develop/bindings/nodejs/examples/how_tos/outputs/unlock-conditions.ts

--- a/next/docs/iota-sdk/docs/how-tos/sign-and-verify-ed25519/sign-ed25519.mdx
+++ b/next/docs/iota-sdk/docs/how-tos/sign-and-verify-ed25519/sign-ed25519.mdx
@@ -29,7 +29,7 @@ https://github.com/iotaledger/iota-sdk/blob/develop/sdk/examples/how_tos/sign_an
 ```
 
 </TabItem>
-<TabItem value="node" label="Node.js">
+<TabItem value="typescript-node" label="Typescript (Node.js)">
 
 ```typescript reference
 https://github.com/iotaledger/iota-sdk/blob/develop/bindings/nodejs/examples/how_tos/sign_and_verify_ed25519/sign-ed25519.ts

--- a/next/docs/iota-sdk/docs/how-tos/sign-and-verify-ed25519/verify-ed25519-signature.mdx
+++ b/next/docs/iota-sdk/docs/how-tos/sign-and-verify-ed25519/verify-ed25519-signature.mdx
@@ -29,7 +29,7 @@ https://github.com/iotaledger/iota-sdk/blob/develop/sdk/examples/how_tos/sign_an
 ```
 
 </TabItem>
-<TabItem value="node" label="Node.js">
+<TabItem value="typescript-node" label="Typescript (Node.js)">
 
 ```typescript reference
 https://github.com/iotaledger/iota-sdk/blob/develop/bindings/nodejs/examples/how_tos/sign_and_verify_ed25519/verify-ed25519-signature.ts

--- a/next/docs/iota-sdk/docs/how-tos/simple-transaction/request-funds.mdx
+++ b/next/docs/iota-sdk/docs/how-tos/simple-transaction/request-funds.mdx
@@ -39,7 +39,7 @@ https://github.com/iotaledger/iota-sdk/blob/develop/sdk/examples/how_tos/simple_
 ```
 
 </TabItem>
-<TabItem value="node" label="Node.js">
+<TabItem value="typescript-node" label="Typescript (Node.js)">
 
 ```typescript reference
 https://github.com/iotaledger/iota-sdk/blob/develop/bindings/nodejs/examples/how_tos/simple_transaction/request-funds.ts

--- a/next/docs/iota-sdk/docs/how-tos/simple-transaction/simple-transaction.mdx
+++ b/next/docs/iota-sdk/docs/how-tos/simple-transaction/simple-transaction.mdx
@@ -38,7 +38,7 @@ https://github.com/iotaledger/iota-sdk/blob/develop/sdk/examples/how_tos/simple_
 ```
 
 </TabItem>
-<TabItem value="node" label="Node.js">
+<TabItem value="typescript-node" label="Typescript (Node.js)">
 
 ```typescript reference
 https://github.com/iotaledger/iota-sdk/blob/develop/bindings/nodejs/examples/how_tos/simple_transaction/simple-transaction.ts

--- a/shimmer/docs/identity.rs/0.7-alpha/docs/concepts/decentralized_identifiers/create.mdx
+++ b/shimmer/docs/identity.rs/0.7-alpha/docs/concepts/decentralized_identifiers/create.mdx
@@ -26,7 +26,7 @@ https://github.com/iotaledger/identity.rs/blob/main/examples/0_basic/0_create_di
 ```
 
 </TabItem>
-<TabItem value="node" label="Node.js">
+<TabItem value="typescript-node" label="Typescript (Node.js)">
 
 ```ts reference
 https://github.com/iotaledger/identity.rs/blob/main/bindings/wasm/examples/src/0_basic/0_create_did.ts

--- a/shimmer/docs/identity.rs/0.7-alpha/docs/concepts/decentralized_identifiers/delete.mdx
+++ b/shimmer/docs/identity.rs/0.7-alpha/docs/concepts/decentralized_identifiers/delete.mdx
@@ -42,7 +42,7 @@ https://github.com/iotaledger/identity.rs/blob/main/examples/0_basic/3_deactivat
 ```
 
 </TabItem>
-<TabItem value="node" label="Node.js">
+<TabItem value="typescript-node" label="Typescript (Node.js)">
 
 ```ts reference
 https://github.com/iotaledger/identity.rs/blob/main/bindings/wasm/examples/src/0_basic/3_deactivate_did.ts
@@ -79,7 +79,7 @@ https://github.com/iotaledger/identity.rs/blob/main/examples/0_basic/4_delete_di
 ```
 
 </TabItem>
-<TabItem value="node" label="Node.js">
+<TabItem value="typescript-node" label="Typescript (Node.js)">
 
 ```ts reference
 https://github.com/iotaledger/identity.rs/blob/main/bindings/wasm/examples/src/0_basic/4_delete_did.ts

--- a/shimmer/docs/identity.rs/0.7-alpha/docs/concepts/decentralized_identifiers/resolve.mdx
+++ b/shimmer/docs/identity.rs/0.7-alpha/docs/concepts/decentralized_identifiers/resolve.mdx
@@ -58,7 +58,7 @@ async fn main() -> anyhow::Result<()>{
 ```
 
 </TabItem>
-<TabItem value="node" label="Node.js">
+<TabItem value="typescript-node" label="Typescript (Node.js)">
 
 ```js
 const {
@@ -119,7 +119,7 @@ async fn main() -> anyhow::Result<()>{
 ```
 
 </TabItem>
-<TabItem value="node" label="Node.js">
+<TabItem value="typescript-node" label="Typescript (Node.js)">
 
 ```js
 const { IotaDID, IotaIdentityClient } = require('@iota/identity-wasm/node');
@@ -158,7 +158,7 @@ https://github.com/iotaledger/identity.rs/blob/main/examples/1_advanced/5_custom
 ```
 
 </TabItem>
-<TabItem value="node" label="Node.js">
+<TabItem value="typescript-node" label="Typescript (Node.js)">
 
 ```ts reference
 https://github.com/iotaledger/identity.rs/blob/main/bindings/wasm/examples/src/1_advanced/4_custom_resolution.ts

--- a/shimmer/docs/identity.rs/0.7-alpha/docs/concepts/decentralized_identifiers/update.mdx
+++ b/shimmer/docs/identity.rs/0.7-alpha/docs/concepts/decentralized_identifiers/update.mdx
@@ -75,7 +75,7 @@ https://github.com/iotaledger/identity.rs/blob/main/examples/0_basic/1_update_di
 ```
 
 </TabItem>
-<TabItem value="node" label="Node.js">
+<TabItem value="typescript-node" label="Typescript (Node.js)">
 
 ```ts reference
 https://github.com/iotaledger/identity.rs/blob/main/bindings/wasm/examples/src/0_basic/1_update_did.ts
@@ -108,7 +108,7 @@ let (_, did): (Address, StardustDID) = create_did(&client, &mut secret_manager).
 ```
 
 </TabItem>
-<TabItem value="node" label="Node.js">
+<TabItem value="typescript-node" label="Typescript (Node.js)">
 
 ```js
 const { didClient, secretManager, did } = await createIdentity();
@@ -153,7 +153,7 @@ This creates and publishes an Alias Output containing a DID Document with one ve
 ```
 
 </TabItem>
-<TabItem value="node" label="Node.js">
+<TabItem value="typescript-node" label="Typescript (Node.js)">
 
 ```js
 // Insert a new Ed25519 verification method in the DID document.
@@ -216,7 +216,7 @@ document.attach_method_relationship(
 ```
 
 </TabItem>
-<TabItem value="node" label="Node.js">
+<TabItem value="typescript-node" label="Typescript (Node.js)">
 
 ```js
 // Attach a new method relationship to the existing method.
@@ -277,7 +277,7 @@ document.metadata.updated = Some(Timestamp::now_utc());
 ```
 
 </TabItem>
-<TabItem value="node" label="Node.js">
+<TabItem value="typescript-node" label="Typescript (Node.js)">
 
 ```js
 // Add a new Service.
@@ -345,7 +345,7 @@ document.remove_method(&original_method).unwrap();
 ```
 
 </TabItem>
-<TabItem value="node" label="Node.js">
+<TabItem value="typescript-node" label="Typescript (Node.js)">
 
 ```js
 // Remove a verification method.
@@ -411,7 +411,7 @@ let updated: StardustDocument = client.publish_did_output(&secret_manager, alias
 ```
 
 </TabItem>
-<TabItem value="node" label="Node.js">
+<TabItem value="typescript-node" label="Typescript (Node.js)">
 
 ```js
 // Resolve the latest output and update it with the given document.

--- a/shimmer/docs/identity.rs/0.7-alpha/docs/concepts/domain_linkage/domain_linkage.mdx
+++ b/shimmer/docs/identity.rs/0.7-alpha/docs/concepts/domain_linkage/domain_linkage.mdx
@@ -137,7 +137,7 @@ https://github.com/iotaledger/identity.rs/blob/main/examples/1_advanced/6_domain
 ```
 
 </TabItem>
-<TabItem value="node" label="Node.js">
+<TabItem value="typescript-node" label="Typescript (Node.js)">
 
 ```ts reference
 https://github.com/iotaledger/identity.rs/blob/main/bindings/wasm/examples/src/1_advanced/5_domain_linkage.ts

--- a/shimmer/docs/identity.rs/0.7-alpha/docs/concepts/verifiable_credentials/create.mdx
+++ b/shimmer/docs/identity.rs/0.7-alpha/docs/concepts/verifiable_credentials/create.mdx
@@ -91,7 +91,7 @@ https://github.com/iotaledger/identity.rs/blob/main/examples/0_basic/5_create_vc
 ```
 
 </TabItem>
-<TabItem value="node" label="Node.js">
+<TabItem value="typescript-node" label="Typescript (Node.js)">
 
 ```ts reference
 https://github.com/iotaledger/identity.rs/blob/main/bindings/wasm/examples/src/0_basic/5_create_vc.ts

--- a/shimmer/docs/identity.rs/0.7-alpha/docs/concepts/verifiable_credentials/revocation.mdx
+++ b/shimmer/docs/identity.rs/0.7-alpha/docs/concepts/verifiable_credentials/revocation.mdx
@@ -62,7 +62,7 @@ https://github.com/iotaledger/identity.rs/blob/main/examples/0_basic/7_revoke_vc
 ```
 
 </TabItem>
-<TabItem value="node" label="Node.js">
+<TabItem value="typescript-node" label="Typescript (Node.js)">
 
 ```ts reference
 https://github.com/iotaledger/identity.rs/blob/main/bindings/wasm/examples/src/0_basic/7_revoke_vc.ts

--- a/shimmer/docs/identity.rs/0.7-alpha/docs/concepts/verifiable_credentials/verifiable_presentations.mdx
+++ b/shimmer/docs/identity.rs/0.7-alpha/docs/concepts/verifiable_credentials/verifiable_presentations.mdx
@@ -174,7 +174,7 @@ https://github.com/iotaledger/identity.rs/blob/main/examples/0_basic/6_create_vp
 ```
 
 </TabItem>
-<TabItem value="node" label="Node.js">
+<TabItem value="typescript-node" label="Typescript (Node.js)">
 
 ```ts reference
 https://github.com/iotaledger/identity.rs/blob/main/bindings/wasm/examples/src/0_basic/6_create_vp.ts

--- a/shimmer/docs/identity.rs/0.7-alpha/docs/getting_started/create_and_publish.mdx
+++ b/shimmer/docs/identity.rs/0.7-alpha/docs/getting_started/create_and_publish.mdx
@@ -36,7 +36,7 @@ https://github.com/iotaledger/identity.rs/blob/main/examples/0_basic/0_create_di
 ```
 
 </TabItem>
-<TabItem value="node" label="Node.js">
+<TabItem value="typescript-node" label="Typescript (Node.js)">
 
 ```ts reference
 https://github.com/iotaledger/identity.rs/blob/main/bindings/wasm/examples/src/0_basic/0_create_did.ts

--- a/shimmer/docs/iota.rs/docs/how_tos/00_run_how_tos.mdx
+++ b/shimmer/docs/iota.rs/docs/how_tos/00_run_how_tos.mdx
@@ -27,7 +27,7 @@ Each language has different set up instructions you need to follow to get the co
   <TabItem value='rust' label='Rust'>
     <RustGetCode />
   </TabItem>
-  <TabItem value='node' label='Node.js'>
+  <TabItem value='typescript-node' label='Typescript (Node.js)'>
     <NodejsGetCode />
   </TabItem>
   <TabItem value='python' label='Python'>

--- a/shimmer/docs/iota.rs/docs/how_tos/01_get_node_info.mdx
+++ b/shimmer/docs/iota.rs/docs/how_tos/01_get_node_info.mdx
@@ -45,7 +45,7 @@ The following code example will:
   <TabItem value='rust' label='Rust'>
     <RustCode />
   </TabItem>
-  <TabItem value='node' label='Node.js'>
+  <TabItem value='typescript-node' label='Typescript (Node.js)'>
     <NodejsCode />
   </TabItem>
   <TabItem value='python' label='Python'>
@@ -62,7 +62,7 @@ The following code example will:
   <TabItem value='rust' label='Rust'>
     <RustOutput />
   </TabItem>
-  <TabItem value='node' label='Node.js'>
+  <TabItem value='typescript-node' label='Typescript (Node.js)'>
     <NodejsOutput />
   </TabItem>
   <TabItem value='python' label='Python'>

--- a/shimmer/docs/iota.rs/docs/how_tos/02_generate_mnemonic.mdx
+++ b/shimmer/docs/iota.rs/docs/how_tos/02_generate_mnemonic.mdx
@@ -36,7 +36,7 @@ The following code example will:
   <TabItem value='rust' label='Rust'>
     <RustCode />
   </TabItem>
-  <TabItem value='node' label='Node.js'>
+  <TabItem value='typescript-node' label='Typescript (Node.js)'>
     <NodejsCode />
   </TabItem>
   <TabItem value='python' label='Python'>
@@ -53,7 +53,7 @@ The following code example will:
   <TabItem value='rust' label='Rust'>
     <RustOutput />
   </TabItem>
-  <TabItem value='node' label='Node.js'>
+  <TabItem value='typescript-node' label='Typescript (Node.js)'>
     <NodejsOutput />
   </TabItem>
   <TabItem value='python' label='Python'>

--- a/shimmer/docs/iota.rs/docs/how_tos/03_generate_addresses.mdx
+++ b/shimmer/docs/iota.rs/docs/how_tos/03_generate_addresses.mdx
@@ -46,7 +46,7 @@ The following code example will:
   <TabItem value='rust' label='Rust'>
     <RustCode />
   </TabItem>
-  <TabItem value='node' label='Node.js'>
+  <TabItem value='typescript-node' label='Typescript (Node.js)'>
     <NodejsCode />
   </TabItem>
   <TabItem value='python' label='Python'>
@@ -63,7 +63,7 @@ The following code example will:
   <TabItem value='rust' label='Rust'>
     <RustOutput />
   </TabItem>
-  <TabItem value='node' label='Node.js'>
+  <TabItem value='typescript-node' label='Typescript (Node.js)'>
     <NodejsOutput />
   </TabItem>
   <TabItem value='python' label='Python'>

--- a/shimmer/docs/iota.rs/docs/how_tos/04_get_output.mdx
+++ b/shimmer/docs/iota.rs/docs/how_tos/04_get_output.mdx
@@ -37,7 +37,7 @@ The following code example will:
   <TabItem value='rust' label='Rust'>
     <RustCode />
   </TabItem>
-  <TabItem value='node' label='Node.js'>
+  <TabItem value='typescript-node' label='Typescript (Node.js)'>
     <NodejsCode />
   </TabItem>
   <TabItem value='python' label='Python'>
@@ -54,7 +54,7 @@ The following code example will:
   <TabItem value='rust' label='Rust'>
     <RustOutput />
   </TabItem>
-  <TabItem value='node' label='Node.js'>
+  <TabItem value='typescript-node' label='Typescript (Node.js)'>
     <NodejsOutput />
   </TabItem>
   <TabItem value='python' label='Python'>

--- a/shimmer/docs/iota.rs/docs/how_tos/05_build_output.mdx
+++ b/shimmer/docs/iota.rs/docs/how_tos/05_build_output.mdx
@@ -40,7 +40,7 @@ The following code example will:
   <TabItem value='rust' label='Rust'>
     <RustCode />
   </TabItem>
-  <TabItem value='node' label='Node.js'>
+  <TabItem value='typescript-node' label='Typescript (Node.js)'>
     <NodejsCode />
   </TabItem>
   <TabItem value='python' label='Python'>
@@ -57,7 +57,7 @@ The following code example will:
   <TabItem value='rust' label='Rust'>
     <RustOutput />
   </TabItem>
-  <TabItem value='node' label='Node.js'>
+  <TabItem value='typescript-node' label='Typescript (Node.js)'>
     <NodejsOutput />
   </TabItem>
   <TabItem value='python' label='Python'>

--- a/shimmer/docs/iota.rs/docs/how_tos/06_get_address_balances.mdx
+++ b/shimmer/docs/iota.rs/docs/how_tos/06_get_address_balances.mdx
@@ -42,7 +42,7 @@ The following code example will:
   <TabItem value='rust' label='Rust'>
     <RustCode />
   </TabItem>
-  <TabItem value='node' label='Node.js'>
+  <TabItem value='typescript-node' label='Typescript (Node.js)'>
     <NodejsCode />
   </TabItem>
   <TabItem value='python' label='Python'>
@@ -59,7 +59,7 @@ The following code example will:
   <TabItem value='rust' label='Rust'>
     <RustOutput />
   </TabItem>
-  <TabItem value='node' label='Node.js'>
+  <TabItem value='typescript-node' label='Typescript (Node.js)'>
     <NodejsOutput />
   </TabItem>
   <TabItem value='python' label='Python'>

--- a/shimmer/docs/iota.rs/docs/how_tos/07_create_block.mdx
+++ b/shimmer/docs/iota.rs/docs/how_tos/07_create_block.mdx
@@ -39,7 +39,7 @@ The following code example will:
   <TabItem value='rust' label='Rust'>
     <RustCode />
   </TabItem>
-  <TabItem value='node' label='Node.js'>
+  <TabItem value='typescript-node' label='Typescript (Node.js)'>
     <NodejsCode />
   </TabItem>
   <TabItem value='python' label='Python'>
@@ -56,7 +56,7 @@ The following code example will:
   <TabItem value='rust' label='Rust'>
     <RustOutput />
   </TabItem>
-  <TabItem value='node' label='Node.js'>
+  <TabItem value='typescript-node' label='Typescript (Node.js)'>
     <NodejsOutput />
   </TabItem>
   <TabItem value='python' label='Python'>

--- a/shimmer/docs/iota.rs/docs/how_tos/08_post_block.mdx
+++ b/shimmer/docs/iota.rs/docs/how_tos/08_post_block.mdx
@@ -54,7 +54,7 @@ The following code example will:
   <TabItem value='rust' label='Rust'>
     <RustCode />
   </TabItem>
-  <TabItem value='node' label='Node.js'>
+  <TabItem value='typescript-node' label='Typescript (Node.js)'>
     <NodejsCode />
   </TabItem>
   <TabItem value='python' label='Python'>
@@ -71,7 +71,7 @@ The following code example will:
   <TabItem value='rust' label='Rust'>
     <RustOutput />
   </TabItem>
-  <TabItem value='node' label='Node.js'>
+  <TabItem value='typescript-node' label='Typescript (Node.js)'>
     <NodejsOutput />
   </TabItem>
   <TabItem value='python' label='Python'>
@@ -90,7 +90,7 @@ The following code example will:
   <TabItem value='rust' label='Rust'>
     <RustRawCode />
   </TabItem>
-  <TabItem value='node' label='Node.js'>
+  <TabItem value='typescript-node' label='Typescript (Node.js)'>
     <NodeJsRawCode />
   </TabItem>
   <TabItem value='python' label='Python'>
@@ -107,7 +107,7 @@ The following code example will:
   <TabItem value='rust' label='Rust'>
     <RustRawOutput />
   </TabItem>
-  <TabItem value='node' label='Node.js'>
+  <TabItem value='typescript-node' label='Typescript (Node.js)'>
     <NodeJsRawOutput />
   </TabItem>
   <TabItem value='python' label='Python'>

--- a/shimmer/docs/iota.rs/docs/how_tos/09_get_block.mdx
+++ b/shimmer/docs/iota.rs/docs/how_tos/09_get_block.mdx
@@ -46,7 +46,7 @@ The following code example will:
   <TabItem value='rust' label='Rust'>
     <RustCode />
   </TabItem>
-  <TabItem value='node' label='Node.js'>
+  <TabItem value='typescript-node' label='Typescript (Node.js)'>
     <NodejsCode />
   </TabItem>
   <TabItem value='python' label='Python'>
@@ -63,7 +63,7 @@ The following code example will:
   <TabItem value='rust' label='Rust'>
     <RustOutput />
   </TabItem>
-  <TabItem value='node' label='Node.js'>
+  <TabItem value='typescript-node' label='Typescript (Node.js)'>
     <NodejsOutput />
   </TabItem>
   <TabItem value='python' label='Python'>

--- a/shimmer/docs/iota.rs/docs/how_tos/10_prepare_sign_transaction.mdx
+++ b/shimmer/docs/iota.rs/docs/how_tos/10_prepare_sign_transaction.mdx
@@ -44,7 +44,7 @@ The following code example will:
   <TabItem value='rust' label='Rust'>
     <RustCode />
   </TabItem>
-  <TabItem value='node' label='Node.js'>
+  <TabItem value='typescript-node' label='Typescript (Node.js)'>
     <NodejsCode />
   </TabItem>
   <TabItem value='python' label='Python'>
@@ -61,7 +61,7 @@ The following code example will:
   <TabItem value='rust' label='Rust'>
     <RustOutput />
   </TabItem>
-  <TabItem value='node' label='Node.js'>
+  <TabItem value='typescript-node' label='Typescript (Node.js)'>
     <NodejsOutput />
   </TabItem>
   <TabItem value='python' label='Python'>

--- a/shimmer/docs/iota.rs/docs/how_tos/11_build_nft_output.mdx
+++ b/shimmer/docs/iota.rs/docs/how_tos/11_build_nft_output.mdx
@@ -40,7 +40,7 @@ The following code example will:
   <TabItem value='rust' label='Rust'>
     <RustCode />
   </TabItem>
-  <TabItem value='node' label='Node.js'>
+  <TabItem value='typescript-node' label='Typescript (Node.js)'>
     <NodejsCode />
   </TabItem>
   <TabItem value='python' label='Python'>
@@ -57,7 +57,7 @@ The following code example will:
   <TabItem value='rust' label='Rust'>
     <RustOutput />
   </TabItem>
-  <TabItem value='node' label='Node.js'>
+  <TabItem value='typescript-node' label='Typescript (Node.js)'>
     <NodejsOutput />
   </TabItem>
   <TabItem value='python' label='Python'>

--- a/shimmer/docs/iota.rs/docs/how_tos/12_build_foundry_output.mdx
+++ b/shimmer/docs/iota.rs/docs/how_tos/12_build_foundry_output.mdx
@@ -35,7 +35,7 @@ The following code example will:
   <TabItem value='rust' label='Rust'>
     <RustCode />
   </TabItem>
-  <TabItem value='node' label='Node.js'>
+  <TabItem value='typescript-node' label='Typescript (Node.js)'>
     <NodejsCode />
   </TabItem>
   <TabItem value='python' label='Python'>
@@ -52,7 +52,7 @@ The following code example will:
   <TabItem value='rust' label='Rust'>
     <RustOutput />
   </TabItem>
-  <TabItem value='node' label='Node.js'>
+  <TabItem value='typescript-node' label='Typescript (Node.js)'>
     <NodejsOutput />
   </TabItem>
   <TabItem value='python' label='Python'>

--- a/shimmer/docs/iota.rs/docs/how_tos/13_build_alias_output.mdx
+++ b/shimmer/docs/iota.rs/docs/how_tos/13_build_alias_output.mdx
@@ -35,7 +35,7 @@ The following code example will:
   <TabItem value='rust' label='Rust'>
     <RustCode />
   </TabItem>
-  <TabItem value='node' label='Node.js'>
+  <TabItem value='typescript-node' label='Typescript (Node.js)'>
     <NodejsCode />
   </TabItem>
   <TabItem value='python' label='Python'>
@@ -52,7 +52,7 @@ The following code example will:
   <TabItem value='rust' label='Rust'>
     <RustOutput />
   </TabItem>
-  <TabItem value='node' label='Node.js'>
+  <TabItem value='typescript-node' label='Typescript (Node.js)'>
     <NodejsOutput />
   </TabItem>
   <TabItem value='python' label='Python'>

--- a/shimmer/docs/iota.rs/docs/how_tos/14_mqtt.mdx
+++ b/shimmer/docs/iota.rs/docs/how_tos/14_mqtt.mdx
@@ -36,7 +36,7 @@ The following code example will:
   <TabItem value='rust' label='Rust'>
     <RustCode />
   </TabItem>
-  <TabItem value='node' label='Node.js'>
+  <TabItem value='typescript-node' label='Typescript (Node.js)'>
     <NodejsCode />
   </TabItem>
   <TabItem value='python' label='Python'>
@@ -53,7 +53,7 @@ The following code example will:
   <TabItem value='rust' label='Rust'>
     <RustOutput />
   </TabItem>
-  <TabItem value='node' label='Node.js'>
+  <TabItem value='typescript-node' label='Typescript (Node.js)'>
     <NodejsOutput />
   </TabItem>
   <TabItem value='python' label='Python'>

--- a/shimmer/docs/wallet.rs/docs/how_tos/NFT/01_mint_nft.mdx
+++ b/shimmer/docs/wallet.rs/docs/how_tos/NFT/01_mint_nft.mdx
@@ -46,7 +46,7 @@ The following example will:
   <TabItem value='rust' label='Rust'>
     <RustCode />
   </TabItem>
-  <TabItem value='node' label='Node.js'>
+  <TabItem value='typescript-node' label='Typescript (Node.js)'>
     <NodejsCode />
   </TabItem>
   <TabItem value='python' label='Python'>
@@ -63,7 +63,7 @@ The following example will:
   <TabItem value='rust' label='Rust'>
     <RustOutput />
   </TabItem>
-  <TabItem value='node' label='Node.js'>
+  <TabItem value='typescript-node' label='Typescript (Node.js)'>
     <NodejsOutput />
   </TabItem>
   <TabItem value='python' label='Python'>

--- a/shimmer/docs/wallet.rs/docs/how_tos/NFT/02_send_nft.mdx
+++ b/shimmer/docs/wallet.rs/docs/how_tos/NFT/02_send_nft.mdx
@@ -51,7 +51,7 @@ The following example will:
   <TabItem value='rust' label='Rust'>
     <RustCode />
   </TabItem>
-  <TabItem value='node' label='Node.js'>
+  <TabItem value='typescript-node' label='Typescript (Node.js)'>
     <NodejsCode />
   </TabItem>
   <TabItem value='python' label='Python'>
@@ -68,7 +68,7 @@ The following example will:
   <TabItem value='rust' label='Rust'>
     <RustOutput />
   </TabItem>
-  <TabItem value='node' label='Node.js'>
+  <TabItem value='typescript-node' label='Typescript (Node.js)'>
     <NodejsOutput />
   </TabItem>
   <TabItem value='python' label='Python'>

--- a/shimmer/docs/wallet.rs/docs/how_tos/NFT/03_burn_nft.mdx
+++ b/shimmer/docs/wallet.rs/docs/how_tos/NFT/03_burn_nft.mdx
@@ -44,7 +44,7 @@ The following example will:
   <TabItem value='rust' label='Rust'>
     <RustCode />
   </TabItem>
-  <TabItem value='node' label='Node.js'>
+  <TabItem value='typescript-node' label='Typescript (Node.js)'>
     <NodejsCode />
   </TabItem>
   <TabItem value='python' label='Python'>
@@ -61,7 +61,7 @@ The following example will:
   <TabItem value='rust' label='Rust'>
     <RustOutput />
   </TabItem>
-  <TabItem value='node' label='Node.js'>
+  <TabItem value='typescript-node' label='Typescript (Node.js)'>
     <NodejsOutput />
   </TabItem>
   <TabItem value='python' label='Python'>

--- a/shimmer/docs/wallet.rs/docs/how_tos/accounts_and_addresses/01_create_a_wallet_account.mdx
+++ b/shimmer/docs/wallet.rs/docs/how_tos/accounts_and_addresses/01_create_a_wallet_account.mdx
@@ -43,7 +43,7 @@ The following example will:
   <TabItem value='rust' label='Rust'>
     <RustCode />
   </TabItem>
-  <TabItem value='node' label='Node.js'>
+  <TabItem value='typescript-node' label='Typescript (Node.js)'>
     <NodejsCode />
   </TabItem>
   <TabItem value='python' label='Python'>
@@ -60,7 +60,7 @@ The following example will:
   <TabItem value='rust' label='Rust'>
     <RustOutput />
   </TabItem>
-  <TabItem value='node' label='Node.js'>
+  <TabItem value='typescript-node' label='Typescript (Node.js)'>
     <NodejsOutput />
   </TabItem>
   <TabItem value='python' label='Python'>

--- a/shimmer/docs/wallet.rs/docs/how_tos/accounts_and_addresses/02_generate_address.mdx
+++ b/shimmer/docs/wallet.rs/docs/how_tos/accounts_and_addresses/02_generate_address.mdx
@@ -46,7 +46,7 @@ The following example will:
   <TabItem value='rust' label='Rust'>
     <RustCode />
   </TabItem>
-  <TabItem value='node' label='Node.js'>
+  <TabItem value='typescript-node' label='Typescript (Node.js)'>
     <NodejsCode />
   </TabItem>
   <TabItem value='python' label='Python'>
@@ -63,7 +63,7 @@ The following example will:
   <TabItem value='rust' label='Rust'>
     <RustOutput />
   </TabItem>
-  <TabItem value='node' label='Node.js'>
+  <TabItem value='typescript-node' label='Typescript (Node.js)'>
     <NodejsOutput />
   </TabItem>
   <TabItem value='python' label='Python'>

--- a/shimmer/docs/wallet.rs/docs/how_tos/accounts_and_addresses/03_request_funds.mdx
+++ b/shimmer/docs/wallet.rs/docs/how_tos/accounts_and_addresses/03_request_funds.mdx
@@ -44,7 +44,7 @@ The following example will:
   <TabItem value='rust' label='Rust'>
     <RustCode />
   </TabItem>
-  <TabItem value='node' label='Node.js'>
+  <TabItem value='typescript-node' label='Typescript (Node.js)'>
     <NodejsCode />
   </TabItem>
   <TabItem value='python' label='Python'>
@@ -61,7 +61,7 @@ The following example will:
   <TabItem value='rust' label='Rust'>
     <RustOutput />
   </TabItem>
-  <TabItem value='node' label='Node.js'>
+  <TabItem value='typescript-node' label='Typescript (Node.js)'>
     <NodejsOutput />
   </TabItem>
   <TabItem value='python' label='Python'>

--- a/shimmer/docs/wallet.rs/docs/how_tos/accounts_and_addresses/04_check_balance.mdx
+++ b/shimmer/docs/wallet.rs/docs/how_tos/accounts_and_addresses/04_check_balance.mdx
@@ -46,7 +46,7 @@ The following example will:
   <TabItem value='rust' label='Rust'>
     <RustCode />
   </TabItem>
-  <TabItem value='node' label='Node.js'>
+  <TabItem value='typescript-node' label='Typescript (Node.js)'>
     <NodejsCode />
   </TabItem>
   <TabItem value='python' label='Python'>
@@ -63,7 +63,7 @@ The following example will:
   <TabItem value='rust' label='Rust'>
     <RustOutput />
   </TabItem>
-  <TabItem value='node' label='Node.js'>
+  <TabItem value='typescript-node' label='Typescript (Node.js)'>
     <NodejsOutput />
   </TabItem>
   <TabItem value='python' label='Python'>

--- a/shimmer/docs/wallet.rs/docs/how_tos/native_tokens/01_mint_native_token.mdx
+++ b/shimmer/docs/wallet.rs/docs/how_tos/native_tokens/01_mint_native_token.mdx
@@ -45,7 +45,7 @@ The following example will:
   <TabItem value='rust' label='Rust'>
     <RustCode />
   </TabItem>
-  <TabItem value='node' label='Node.js'>
+  <TabItem value='typescript-node' label='Typescript (Node.js)'>
     <NodejsCode />
   </TabItem>
   <TabItem value='python' label='Python'>
@@ -62,7 +62,7 @@ The following example will:
   <TabItem value='rust' label='Rust'>
     <RustOutput />
   </TabItem>
-  <TabItem value='node' label='Node.js'>
+  <TabItem value='typescript-node' label='Typescript (Node.js)'>
     <NodejsOutput />
   </TabItem>
   <TabItem value='python' label='Python'>

--- a/shimmer/docs/wallet.rs/docs/how_tos/native_tokens/02_send_native_token.mdx
+++ b/shimmer/docs/wallet.rs/docs/how_tos/native_tokens/02_send_native_token.mdx
@@ -51,7 +51,7 @@ The following example will:
   <TabItem value='rust' label='Rust'>
     <RustCode />
   </TabItem>
-  <TabItem value='node' label='Node.js'>
+  <TabItem value='typescript-node' label='Typescript (Node.js)'>
     <NodejsCode />
   </TabItem>
   <TabItem value='python' label='Python'>
@@ -68,7 +68,7 @@ The following example will:
   <TabItem value='rust' label='Rust'>
     <RustOutput />
   </TabItem>
-  <TabItem value='node' label='Node.js'>
+  <TabItem value='typescript-node' label='Typescript (Node.js)'>
     <NodejsOutput />
   </TabItem>
   <TabItem value='python' label='Python'>

--- a/shimmer/docs/wallet.rs/docs/how_tos/native_tokens/03_melt_native_token.mdx
+++ b/shimmer/docs/wallet.rs/docs/how_tos/native_tokens/03_melt_native_token.mdx
@@ -45,7 +45,7 @@ The following example will:
   <TabItem value='rust' label='Rust'>
     <RustCode />
   </TabItem>
-  <TabItem value='node' label='Node.js'>
+  <TabItem value='typescript-node' label='Typescript (Node.js)'>
     <NodejsCode />
   </TabItem>
   <TabItem value='python' label='Python'>
@@ -62,7 +62,7 @@ The following example will:
   <TabItem value='rust' label='Rust'>
     <RustOutput />
   </TabItem>
-  <TabItem value='node' label='Node.js'>
+  <TabItem value='typescript-node' label='Typescript (Node.js)'>
     <NodejsOutput />
   </TabItem>
   <TabItem value='python' label='Python'>

--- a/shimmer/docs/wallet.rs/docs/how_tos/native_tokens/04_burn_native_token.mdx
+++ b/shimmer/docs/wallet.rs/docs/how_tos/native_tokens/04_burn_native_token.mdx
@@ -51,7 +51,7 @@ The following example will:
   <TabItem value='rust' label='Rust'>
     <RustCode />
   </TabItem>
-  <TabItem value='node' label='Node.js'>
+  <TabItem value='typescript-node' label='Typescript (Node.js)'>
     <NodejsCode />
   </TabItem>
   <TabItem value='python' label='Python'>
@@ -68,7 +68,7 @@ The following example will:
   <TabItem value='rust' label='Rust'>
     <RustOutput />
   </TabItem>
-  <TabItem value='node' label='Node.js'>
+  <TabItem value='typescript-node' label='Typescript (Node.js)'>
     <NodejsOutput />
   </TabItem>
   <TabItem value='python' label='Python'>

--- a/shimmer/docs/wallet.rs/docs/how_tos/native_tokens/05_destroy_foundry.mdx
+++ b/shimmer/docs/wallet.rs/docs/how_tos/native_tokens/05_destroy_foundry.mdx
@@ -50,7 +50,7 @@ The following example will:
   <TabItem value='rust' label='Rust'>
     <RustCode />
   </TabItem>
-  <TabItem value='node' label='Node.js'>
+  <TabItem value='typescript-node' label='Typescript (Node.js)'>
     <NodejsCode />
   </TabItem>
   <TabItem value='python' label='Python'>
@@ -67,7 +67,7 @@ The following example will:
   <TabItem value='rust' label='Rust'>
     <RustOutput />
   </TabItem>
-  <TabItem value='node' label='Node.js'>
+  <TabItem value='typescript-node' label='Typescript (Node.js)'>
     <NodejsOutput />
   </TabItem>
   <TabItem value='python' label='Python'>

--- a/shimmer/docs/wallet.rs/docs/how_tos/native_tokens/06_destroy_alias_output.mdx
+++ b/shimmer/docs/wallet.rs/docs/how_tos/native_tokens/06_destroy_alias_output.mdx
@@ -40,7 +40,7 @@ The following example will:
   <TabItem value='rust' label='Rust'>
     <RustCode />
   </TabItem>
-  <TabItem value='node' label='Node.js'>
+  <TabItem value='typescript-node' label='Typescript (Node.js)'>
     <NodejsCode />
   </TabItem>
   <TabItem value='python' label='Python'>
@@ -57,7 +57,7 @@ The following example will:
   <TabItem value='rust' label='Rust'>
     <RustOutput />
   </TabItem>
-  <TabItem value='node' label='Node.js'>
+  <TabItem value='typescript-node' label='Typescript (Node.js)'>
     <NodejsOutput />
   </TabItem>
   <TabItem value='python' label='Python'>

--- a/shimmer/docs/wallet.rs/docs/how_tos/outputs_and_transactions/01_send_transaction.mdx
+++ b/shimmer/docs/wallet.rs/docs/how_tos/outputs_and_transactions/01_send_transaction.mdx
@@ -46,7 +46,7 @@ The following example will:
   <TabItem value='rust' label='Rust'>
     <RustCode />
   </TabItem>
-  <TabItem value='node' label='Node.js'>
+  <TabItem value='typescript-node' label='Typescript (Node.js)'>
     <NodejsCode />
   </TabItem>
   <TabItem value='python' label='Python'>
@@ -63,7 +63,7 @@ The following example will:
   <TabItem value='rust' label='Rust'>
     <RustOutput />
   </TabItem>
-  <TabItem value='node' label='Node.js'>
+  <TabItem value='typescript-node' label='Typescript (Node.js)'>
     <NodejsOutput />
   </TabItem>
   <TabItem value='python' label='Python'>

--- a/shimmer/docs/wallet.rs/docs/how_tos/outputs_and_transactions/02_send_micro_transaction.mdx
+++ b/shimmer/docs/wallet.rs/docs/how_tos/outputs_and_transactions/02_send_micro_transaction.mdx
@@ -43,7 +43,7 @@ The following example will:
   <TabItem value='rust' label='Rust'>
     <RustCode />
   </TabItem>
-  <TabItem value='node' label='Node.js'>
+  <TabItem value='typescript-node' label='Typescript (Node.js)'>
     <NodejsCode />
   </TabItem>
   <TabItem value='python' label='Python'>
@@ -60,7 +60,7 @@ The following example will:
   <TabItem value='rust' label='Rust'>
     <RustOutput />
   </TabItem>
-  <TabItem value='node' label='Node.js'>
+  <TabItem value='typescript-node' label='Typescript (Node.js)'>
     <NodejsOutput />
   </TabItem>
   <TabItem value='python' label='Python'>

--- a/shimmer/docs/wallet.rs/docs/how_tos/outputs_and_transactions/03_list_outputs.mdx
+++ b/shimmer/docs/wallet.rs/docs/how_tos/outputs_and_transactions/03_list_outputs.mdx
@@ -41,7 +41,7 @@ The following example will:
   <TabItem value='rust' label='Rust'>
     <RustCode />
   </TabItem>
-  <TabItem value='node' label='Node.js'>
+  <TabItem value='typescript-node' label='Typescript (Node.js)'>
     <NodejsCode />
   </TabItem>
   <TabItem value='python' label='Python'>
@@ -58,7 +58,7 @@ The following example will:
   <TabItem value='rust' label='Rust'>
     <RustOutput />
   </TabItem>
-  <TabItem value='node' label='Node.js'>
+  <TabItem value='typescript-node' label='Typescript (Node.js)'>
     <NodejsOutput />
   </TabItem>
   <TabItem value='python' label='Python'>

--- a/shimmer/docs/wallet.rs/docs/how_tos/outputs_and_transactions/04_claim_outputs.mdx
+++ b/shimmer/docs/wallet.rs/docs/how_tos/outputs_and_transactions/04_claim_outputs.mdx
@@ -43,7 +43,7 @@ The following example will:
   <TabItem value='rust' label='Rust'>
     <RustCode />
   </TabItem>
-  <TabItem value='node' label='Node.js'>
+  <TabItem value='typescript-node' label='Typescript (Node.js)'>
     <NodejsCode />
   </TabItem>
   <TabItem value='python' label='Python'>
@@ -60,7 +60,7 @@ The following example will:
   <TabItem value='rust' label='Rust'>
     <RustOutput />
   </TabItem>
-  <TabItem value='node' label='Node.js'>
+  <TabItem value='typescript-node' label='Typescript (Node.js)'>
     <NodejsOutput />
   </TabItem>
   <TabItem value='python' label='Python'>

--- a/shimmer/docs/wallet.rs/docs/how_tos/outputs_and_transactions/05_list_transactions.mdx
+++ b/shimmer/docs/wallet.rs/docs/how_tos/outputs_and_transactions/05_list_transactions.mdx
@@ -40,7 +40,7 @@ The following example will:
   <TabItem value='rust' label='Rust'>
     <RustCode />
   </TabItem>
-  <TabItem value='node' label='Node.js'>
+  <TabItem value='typescript-node' label='Typescript (Node.js)'>
     <NodejsCode />
   </TabItem>
   <TabItem value='python' label='Python'>
@@ -57,7 +57,7 @@ The following example will:
   <TabItem value='rust' label='Rust'>
     <RustOutput />
   </TabItem>
-  <TabItem value='node' label='Node.js'>
+  <TabItem value='typescript-node' label='Typescript (Node.js)'>
     <NodejsOutput />
   </TabItem>
   <TabItem value='python' label='Python'>

--- a/shimmer/docs/wallet.rs/docs/how_tos/outputs_and_transactions/06_check_unlock_conditions.mdx
+++ b/shimmer/docs/wallet.rs/docs/how_tos/outputs_and_transactions/06_check_unlock_conditions.mdx
@@ -37,7 +37,7 @@ The following example will:
   <TabItem value='rust' label='Rust'>
     <RustCode />
   </TabItem>
-  <TabItem value='node' label='Node.js'>
+  <TabItem value='typescript-node' label='Typescript (Node.js)'>
     <NodejsCode />
   </TabItem>
   <TabItem value='python' label='Python'>
@@ -54,7 +54,7 @@ The following example will:
   <TabItem value='rust' label='Rust'>
     <RustOutput />
   </TabItem>
-  <TabItem value='node' label='Node.js'>
+  <TabItem value='typescript-node' label='Typescript (Node.js)'>
     <NodejsOutput />
   </TabItem>
   <TabItem value='python' label='Python'>

--- a/shimmer/docs/wallet.rs/docs/how_tos/run_how_tos.mdx
+++ b/shimmer/docs/wallet.rs/docs/how_tos/run_how_tos.mdx
@@ -68,7 +68,7 @@ Each language has different set up instructions you need to follow to get the co
   <TabItem value='rust' label='Rust'>
     <RustGetCode />
   </TabItem>
-  <TabItem value='node' label='Node.js'>
+  <TabItem value='typescript-node' label='Typescript (Node.js)'>
     <NodejsGetCode />
   </TabItem>
   <TabItem value='python' label='Python'>


### PR DESCRIPTION
# Description of change

The tabs are about languages, while Node.js and Wasm are compilation targets. As per discussion with @luca-moser I changed it to `Typescript (Node.js)` and `Typescript (Wasm)` respectively.

## Type of change

- Documentation Fix

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the [contribution guidelines](https://github.com/iota-wiki/iota-wiki/blob/main/.github/CONTRIBUTING.md) for this project
- [x] I have performed a self-review of my own changes
- [x] I have made sure that added/changed links still work
