### PR TITLE
Re-add identity card on Shimmer landing page

### DIFF
--- a/src/shimmer/components/HomeLayout/AppLibrariesSection.tsx
+++ b/src/shimmer/components/HomeLayout/AppLibrariesSection.tsx
@@ -1,6 +1,9 @@
+import AppLibImg from '@site/static/img/homepage/section_application_libraries.png';
+import AppLibImgDark from '@site/static/img/homepage/section_application_libraries_dark.png';
+import ThemedImage from '@theme/ThemedImage';
 import React, { FC } from 'react';
 import Link from '@docusaurus/Link';
-import { SmartContracts, Stronghold } from '@site/src/common/icons';
+import { Identity, SmartContracts, Stronghold } from '@site/src/common/icons';
 
 interface LanguagesProps {
   languages?: { [key: string]: string };
@@ -68,6 +71,7 @@ const LibrariesSection: FC = () => (
     </div>
     <div className='libraries__card libraries__card--wide'>
       <img
+        alt='IOTA Smart Contracts'
         className='libraries__logo'
         src='/img/homepage/smartcontracts_bot.svg'
       />
@@ -97,6 +101,42 @@ const LibrariesSection: FC = () => (
           </Link> */}
         </div>
       </div>
+    </div>
+    <div className='libraries__card libraries__card--wide'>
+      <img
+        className='libraries__logo'
+        src='/img/homepage/identity_logo.svg'
+        alt='Identity'
+      />
+      <div className='libraries__section'>
+        <div className='libraries__head'>
+          <div className='libraries__icon'>
+            <Identity />
+          </div>
+        </div>
+        <h3 className='libraries__header'>IOTA Identity</h3>
+        <p className='libraries__body'>
+          The IOTA Identity framework for Decentralized Identity brings a first
+          experimental version to Shimmer
+        </p>
+        <div className='start-building__buttons'>
+          <Link
+            to='/identity.rs/introduction'
+            className='start-building__button button button--outline button--primary'
+          >
+            Learn about Identity
+          </Link>
+        </div>
+      </div>
+    </div>
+    <div className='spaceholder__card__img'>
+      <ThemedImage
+        alt='Core Libraries'
+        sources={{
+          light: AppLibImg,
+          dark: AppLibImgDark,
+        }}
+      />
     </div>
   </div>
 );


### PR DESCRIPTION
# Description of change

With the merge of [`Next` into `Shimmer`](https://github.com/iotaledger/iota-wiki/pull/1054) I accidentally removed the Identity card. This PR reverts that change.

## Links to any relevant issues

Fixes #1067 

## Type of change

- Documentation Fix

## Change checklist

- [x] I have followed the [contribution guidelines](https://github.com/iota-wiki/iota-wiki/blob/main/.github/CONTRIBUTING.md) for this project
- [x] I have performed a self-review of my own changes
- [ ] I have made sure that added/changed links still work
- [ ] I have commented my code, particularly in hard-to-understand areas
