### PR TITLE
Swizzle version banner

### DIFF
--- a/contentPlugins.js
+++ b/contentPlugins.js
@@ -177,7 +177,7 @@ module.exports = async () => {
         current: {
           label: '1.1.0',
           badge: true,
-          banner: 'unmaintained',
+          banner: 'deprecated',
         },
       },
     },

--- a/contentPlugins.js
+++ b/contentPlugins.js
@@ -173,6 +173,13 @@ module.exports = async () => {
         __dirname,
         'docs/build/stronghold.rs/1.1.0/sidebars.js',
       ),
+      versions: {
+        current: {
+          label: '1.1.0',
+          badge: true,
+          banner: 'unmaintained',
+        },
+      },
     },
     {
       id: 'iota-streams',

--- a/src/theme/DocVersionBanner/index.tsx
+++ b/src/theme/DocVersionBanner/index.tsx
@@ -57,7 +57,9 @@ function UnmaintainedVersionLabel({
         versionLabel: <b>{versionMetadata.label}</b>,
       }}
     >
-      {'Version {versionLabel} is being deprecated.'}
+      {
+        'This is documentation for {siteTitle} {versionLabel}, which is no longer actively maintained.'
+      }
     </Translate>
   );
 }
@@ -89,22 +91,24 @@ function LatestVersionSuggestionLabel({
       id='theme.docs.versions.latestVersionSuggestionLabel'
       description='The label used to tell the user to check the latest version'
       values={{
+        versionLabel,
         latestVersionLink: (
           <b>
             <Link to={to} onClick={onClick}>
               <Translate
                 id='theme.docs.versions.latestVersionLinkLabel'
                 description='The label used for the latest version suggestion link label'
-                values={{ versionLabel }}
               >
-                {'{versionLabel}'}
+                latest version
               </Translate>
             </Link>
           </b>
         ),
       }}
     >
-      {'The latest version is {latestVersionLink}.'}
+      {
+        'For up-to-date documentation, see the {latestVersionLink} ({versionLabel}).'
+      }
     </Translate>
   );
 }
@@ -145,17 +149,13 @@ function DocVersionBannerEnabled({
       <div>
         <BannerLabel siteTitle={siteTitle} versionMetadata={versionMetadata} />
       </div>
-      {latestVersionSuggestion.label !== versionMetadata.label && (
-        <div className='margin-top--md'>
-          <LatestVersionSuggestionLabel
-            versionLabel={latestVersionSuggestion.label}
-            to={latestVersionSuggestedDoc.path}
-            onClick={() =>
-              savePreferredVersionName(latestVersionSuggestion.name)
-            }
-          />
-        </div>
-      )}
+      <div className='margin-top--md'>
+        <LatestVersionSuggestionLabel
+          versionLabel={latestVersionSuggestion.label}
+          to={latestVersionSuggestedDoc.path}
+          onClick={() => savePreferredVersionName(latestVersionSuggestion.name)}
+        />
+      </div>
     </div>
   );
 }

--- a/src/theme/DocVersionBanner/index.tsx
+++ b/src/theme/DocVersionBanner/index.tsx
@@ -1,3 +1,11 @@
+/**
+ * SWIZZLED VERSION: 2.4.1
+ * REASONS:
+ *  - Remove use of siteTitle as it is irrelevant in our setup.
+ *  - Link to our own latest version.
+ *  - Add `deprecated` banner.
+ */
+
 import React, { type ComponentType } from 'react';
 import clsx from 'clsx';
 import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
@@ -19,13 +27,14 @@ import type {
   PropVersionMetadata,
 } from '@docusaurus/plugin-content-docs';
 
+type WikiVersionBanner = VersionBanner & 'deprecated';
+
 type BannerLabelComponentProps = {
   siteTitle: string;
   versionMetadata: PropVersionMetadata;
 };
 
 function UnreleasedVersionLabel({
-  siteTitle,
   versionMetadata,
 }: BannerLabelComponentProps) {
   return (
@@ -33,19 +42,15 @@ function UnreleasedVersionLabel({
       id='theme.docs.versions.unreleasedVersionLabel'
       description="The label used to tell the user that he's browsing an unreleased doc version"
       values={{
-        siteTitle,
         versionLabel: <b>{versionMetadata.label}</b>,
       }}
     >
-      {
-        'This is unreleased documentation for {siteTitle} {versionLabel} version.'
-      }
+      {'This is unreleased documentation for {versionLabel} version.'}
     </Translate>
   );
 }
 
 function UnmaintainedVersionLabel({
-  siteTitle,
   versionMetadata,
 }: BannerLabelComponentProps) {
   return (
@@ -53,22 +58,38 @@ function UnmaintainedVersionLabel({
       id='theme.docs.versions.unmaintainedVersionLabel'
       description="The label used to tell the user that he's browsing an unmaintained doc version"
       values={{
-        siteTitle,
         versionLabel: <b>{versionMetadata.label}</b>,
       }}
     >
       {
-        'This is documentation for {siteTitle} {versionLabel}, which is no longer actively maintained.'
+        'This is documentation for {versionLabel}, which is no longer actively maintained.'
       }
     </Translate>
   );
 }
 
+function DeprecatedVersionLabel({
+  versionMetadata,
+}: BannerLabelComponentProps) {
+  return (
+    <Translate
+      id='theme.docs.versions.deprecatedVersionLabel'
+      description="The label used to tell the user that he's browsing a deprecated doc version"
+      values={{
+        versionLabel: <b>{versionMetadata.label}</b>,
+      }}
+    >
+      {'This is documentation for {versionLabel}, which is being deprecated.'}
+    </Translate>
+  );
+}
+
 const BannerLabelComponents: {
-  [banner in VersionBanner]: ComponentType<BannerLabelComponentProps>;
+  [banner in WikiVersionBanner]: ComponentType<BannerLabelComponentProps>;
 } = {
   unreleased: UnreleasedVersionLabel,
   unmaintained: UnmaintainedVersionLabel,
+  deprecated: DeprecatedVersionLabel,
 };
 
 function BannerLabel(props: BannerLabelComponentProps) {
@@ -149,7 +170,7 @@ function DocVersionBannerEnabled({
       <div>
         <BannerLabel siteTitle={siteTitle} versionMetadata={versionMetadata} />
       </div>
-      <div className='margin-top--md'>
+      <div>
         <LatestVersionSuggestionLabel
           versionLabel={latestVersionSuggestion.label}
           to={latestVersionSuggestedDoc.path}

--- a/src/theme/DocVersionBanner/index.tsx
+++ b/src/theme/DocVersionBanner/index.tsx
@@ -57,9 +57,7 @@ function UnmaintainedVersionLabel({
         versionLabel: <b>{versionMetadata.label}</b>,
       }}
     >
-      {
-        'This is documentation for {siteTitle} {versionLabel}, which is no longer actively maintained.'
-      }
+      {'Version {versionLabel} is being deprecated.'}
     </Translate>
   );
 }
@@ -91,24 +89,22 @@ function LatestVersionSuggestionLabel({
       id='theme.docs.versions.latestVersionSuggestionLabel'
       description='The label used to tell the user to check the latest version'
       values={{
-        versionLabel,
         latestVersionLink: (
           <b>
             <Link to={to} onClick={onClick}>
               <Translate
                 id='theme.docs.versions.latestVersionLinkLabel'
                 description='The label used for the latest version suggestion link label'
+                values={{ versionLabel }}
               >
-                latest version
+                {'{versionLabel}'}
               </Translate>
             </Link>
           </b>
         ),
       }}
     >
-      {
-        'For up-to-date documentation, see the {latestVersionLink} ({versionLabel}).'
-      }
+      {'The latest version is {latestVersionLink}.'}
     </Translate>
   );
 }
@@ -149,13 +145,17 @@ function DocVersionBannerEnabled({
       <div>
         <BannerLabel siteTitle={siteTitle} versionMetadata={versionMetadata} />
       </div>
-      <div className='margin-top--md'>
-        <LatestVersionSuggestionLabel
-          versionLabel={latestVersionSuggestion.label}
-          to={latestVersionSuggestedDoc.path}
-          onClick={() => savePreferredVersionName(latestVersionSuggestion.name)}
-        />
-      </div>
+      {latestVersionSuggestion.label !== versionMetadata.label && (
+        <div className='margin-top--md'>
+          <LatestVersionSuggestionLabel
+            versionLabel={latestVersionSuggestion.label}
+            to={latestVersionSuggestedDoc.path}
+            onClick={() =>
+              savePreferredVersionName(latestVersionSuggestion.name)
+            }
+          />
+        </div>
+      )}
     </div>
   );
 }

--- a/src/theme/DocVersionBanner/index.tsx
+++ b/src/theme/DocVersionBanner/index.tsx
@@ -1,0 +1,176 @@
+import React, { type ComponentType } from 'react';
+import clsx from 'clsx';
+import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
+import Link from '@docusaurus/Link';
+import Translate from '@docusaurus/Translate';
+import {
+  useActivePlugin,
+  useDocVersionSuggestions,
+  type GlobalVersion,
+} from '@docusaurus/plugin-content-docs/client';
+import { ThemeClassNames } from '@docusaurus/theme-common';
+import {
+  useDocsPreferredVersion,
+  useDocsVersion,
+} from '@docusaurus/theme-common/internal';
+import type { Props } from '@theme/DocVersionBanner';
+import type {
+  VersionBanner,
+  PropVersionMetadata,
+} from '@docusaurus/plugin-content-docs';
+
+type BannerLabelComponentProps = {
+  siteTitle: string;
+  versionMetadata: PropVersionMetadata;
+};
+
+function UnreleasedVersionLabel({
+  siteTitle,
+  versionMetadata,
+}: BannerLabelComponentProps) {
+  return (
+    <Translate
+      id='theme.docs.versions.unreleasedVersionLabel'
+      description="The label used to tell the user that he's browsing an unreleased doc version"
+      values={{
+        siteTitle,
+        versionLabel: <b>{versionMetadata.label}</b>,
+      }}
+    >
+      {
+        'This is unreleased documentation for {siteTitle} {versionLabel} version.'
+      }
+    </Translate>
+  );
+}
+
+function UnmaintainedVersionLabel({
+  siteTitle,
+  versionMetadata,
+}: BannerLabelComponentProps) {
+  return (
+    <Translate
+      id='theme.docs.versions.unmaintainedVersionLabel'
+      description="The label used to tell the user that he's browsing an unmaintained doc version"
+      values={{
+        siteTitle,
+        versionLabel: <b>{versionMetadata.label}</b>,
+      }}
+    >
+      {
+        'This is documentation for {siteTitle} {versionLabel}, which is no longer actively maintained.'
+      }
+    </Translate>
+  );
+}
+
+const BannerLabelComponents: {
+  [banner in VersionBanner]: ComponentType<BannerLabelComponentProps>;
+} = {
+  unreleased: UnreleasedVersionLabel,
+  unmaintained: UnmaintainedVersionLabel,
+};
+
+function BannerLabel(props: BannerLabelComponentProps) {
+  const BannerLabelComponent =
+    BannerLabelComponents[props.versionMetadata.banner!];
+  return <BannerLabelComponent {...props} />;
+}
+
+function LatestVersionSuggestionLabel({
+  versionLabel,
+  to,
+  onClick,
+}: {
+  to: string;
+  onClick: () => void;
+  versionLabel: string;
+}) {
+  return (
+    <Translate
+      id='theme.docs.versions.latestVersionSuggestionLabel'
+      description='The label used to tell the user to check the latest version'
+      values={{
+        versionLabel,
+        latestVersionLink: (
+          <b>
+            <Link to={to} onClick={onClick}>
+              <Translate
+                id='theme.docs.versions.latestVersionLinkLabel'
+                description='The label used for the latest version suggestion link label'
+              >
+                latest version
+              </Translate>
+            </Link>
+          </b>
+        ),
+      }}
+    >
+      {
+        'For up-to-date documentation, see the {latestVersionLink} ({versionLabel}).'
+      }
+    </Translate>
+  );
+}
+
+function DocVersionBannerEnabled({
+  className,
+  versionMetadata,
+}: Props & {
+  versionMetadata: PropVersionMetadata;
+}): JSX.Element {
+  const {
+    siteConfig: { title: siteTitle },
+  } = useDocusaurusContext();
+  const { pluginId } = useActivePlugin({ failfast: true })!;
+
+  const getVersionMainDoc = (version: GlobalVersion) =>
+    version.docs.find((doc) => doc.id === version.mainDocId)!;
+
+  const { savePreferredVersionName } = useDocsPreferredVersion(pluginId);
+
+  const { latestDocSuggestion, latestVersionSuggestion } =
+    useDocVersionSuggestions(pluginId);
+
+  // Try to link to same doc in latest version (not always possible), falling
+  // back to main doc of latest version
+  const latestVersionSuggestedDoc =
+    latestDocSuggestion ?? getVersionMainDoc(latestVersionSuggestion);
+
+  return (
+    <div
+      className={clsx(
+        className,
+        ThemeClassNames.docs.docVersionBanner,
+        'alert alert--warning margin-bottom--md',
+      )}
+      role='alert'
+    >
+      <div>
+        <BannerLabel siteTitle={siteTitle} versionMetadata={versionMetadata} />
+      </div>
+      <div className='margin-top--md'>
+        <LatestVersionSuggestionLabel
+          versionLabel={latestVersionSuggestion.label}
+          to={latestVersionSuggestedDoc.path}
+          onClick={() => savePreferredVersionName(latestVersionSuggestion.name)}
+        />
+      </div>
+    </div>
+  );
+}
+
+export default function DocVersionBanner({
+  className,
+}: Props): JSX.Element | null {
+  const versionMetadata = useDocsVersion();
+  if (versionMetadata.banner) {
+    return (
+      <DocVersionBannerEnabled
+        className={className}
+        versionMetadata={versionMetadata}
+      />
+    );
+  }
+  return null;
+}


### PR DESCRIPTION
# Description of change

This changes the version banner to show a deprecation caution when 'unmaintained' is used as banner value for that version. It shows a link to the latest version, if available and not the same as the deprecated version.

## Links to any relevant issues

fixes #1087 

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the [contribution guidelines](https://github.com/iota-wiki/iota-wiki/blob/main/.github/CONTRIBUTING.md) for this project
- [x] I have performed a self-review of my own changes
