### PR TITLE
Add category page for wallets

### DIFF
--- a/docs/get-started/sidebars.ts
+++ b/docs/get-started/sidebars.ts
@@ -44,12 +44,20 @@ module.exports = {
     {
       type: 'category',
       label: 'Wallets',
+      link: {
+        type: 'generated-index',
+        title: 'Wallets',
+        description: 'A list of all wallets including community wallets.',
+        slug: '/wallets',
+        keywords: ['wallets', 'firefly', 'tanglepay'],
+      },
       items: [
         'wallets/firefly',
         {
           type: 'link',
           label: 'TanglePay',
           href: 'https://tanglepay.com/',
+          description: 'Your IOTA & Shimmer Wallet for DeFi and NFTs.'
         },
       ],
     },

--- a/docs/get-started/wallets/firefly.md
+++ b/docs/get-started/wallets/firefly.md
@@ -1,6 +1,6 @@
 ---
 title: Firefly Wallet
-description: The Firefly Wallet sets a new standard for Software Wallets in DLT. Learn everything here.
+description: Official wallet from the IOTA Foundation.
 keywords:
   - Firefly Wallet
   - Shimmer Wallet


### PR DESCRIPTION
# Description of change

I added a category page for wallets. This is nice to have a linkable list of available wallets.
I also changed the description for Firefly to make it more obvious that it is the official wallet from IF in the list.

## Type of change

- Documentation Enhancement

## Change checklist

- [x] I have followed the [contribution guidelines](https://github.com/iota-wiki/iota-wiki/blob/main/.github/CONTRIBUTING.md) for this project
- [x] I have performed a self-review of my own changes
- [x] I have made sure that added/changed links still work
- [ ] I have commented my code, particularly in hard-to-understand areas
