### PR TITLE
Added Shimmer++ libraries link

### DIFF
--- a/shimmer/develop/sidebars.ts
+++ b/shimmer/develop/sidebars.ts
@@ -294,6 +294,11 @@ module.exports = {
                   type: 'link',
                   href: 'https://github.com/IOTA-NET/IotaWallet.NET',
                 },
+                {
+                  label: 'Shimmer++',
+                  type: 'link',
+                  href: 'https://eddytheco.github.io/Shimmerpp/about/',
+                },
               ],
             },
           ],


### PR DESCRIPTION
# Description of change

Added the link for Shimmer++ libraries in the `Community Driven Libraries` section.

## Type of change

- Documentation Enhancement

## Change checklist

- [x] I have followed the [contribution guidelines](https://github.com/iota-wiki/iota-wiki/blob/main/.github/CONTRIBUTING.md) for this project
- [x] I have performed a self-review of my own changes
- [x] I have made sure that added/changed links still work
- [x] I have commented my code, particularly in hard-to-understand areas
