### PR TITLE
Restructure - Added intro pages for build and maintain

### DIFF
--- a/contentPlugins.js
+++ b/contentPlugins.js
@@ -255,6 +255,16 @@ module.exports = async () => {
 
   const maintainPlugins = [
     {
+      id: 'maintain',
+      globalSidebars: ['maintain'],
+      path: path.resolve(__dirname, 'docs/maintain/getting-started'),
+      sidebarPath: path.resolve(
+        __dirname,
+        'docs/maintain/getting-started/sidebars.ts',
+      ),
+      routeBasePath: 'maintain',
+    },
+    {
       id: 'hornet-1-2-4',
       path: path.resolve(__dirname, 'docs/maintain/hornet/1.2.4/docs'),
       routeBasePath: 'hornet',

--- a/docs/build/getting-started/sidebars.ts
+++ b/docs/build/getting-started/sidebars.ts
@@ -1,5 +1,6 @@
 module.exports = {
   build: [
+    'welcome',
     {
       type: 'doc',
       label: 'Networks & Endpoints',

--- a/docs/build/getting-started/welcome.md
+++ b/docs/build/getting-started/welcome.md
@@ -1,0 +1,54 @@
+---
+description: 'This section provides a comprehensive guide targeted at developers who want to build on the IOTA network.'
+keywords:
+  [
+    'IOTA',
+    'Development',
+    'API Endpoints',
+    'Networks',
+    'Client Libraries',
+    'Smart Contracts',
+    'Application Libraries',
+  ]
+---
+
+# Welcome
+
+Welcome to the "Build" section of the IOTA Wiki. This section is for developers interested in using the IOTA and Shimmer
+networks for decentralized applications, integrating their exchange, minting NFTs, and much more. Here, you can find all
+the available [Networks and Endpoints](networks-endpoints.md), links for all the available
+[Tools](/build/tools), [APIS](/apis/welcome/), and all the documentation to communicate with the Layer 1 networks,
+build
+decentralized applications and interact with Layer 2 [smart contracts](#smart-contracts).
+
+## Layer 1
+
+### IOTA SDK
+
+You can use the [IOTA SDK](/iota-sdk/welcome) to interact directly with the IOTA and Shimmer networks. The
+IOTA SDK offers a streamlined integration of IOTA functionality into your projects. It is available in
+[Rust](/iota-sdk/getting-started/rust), [Node.js](/iota-sdk/getting-started/nodejs),
+[Python](/iota-sdk/getting-started/python) and [Wasm](/iota-sdk/getting-started/wasm).
+
+### Cli Wallet
+
+The [cli-wallet](/cli-wallet/welcome) is a stateful Command Line Interface wrapper for the IOTA SDK that
+allows you to create a wallet, create and manage accounts, send value transactions, mint, burn, and receive native
+tokens and NFTs, and more.
+
+### Identity
+
+You can use the [IOTA Identity Framework](/identity.rs/introduction) to create and manage
+[Self-Sovereign Identities (SSI)](/identity.rs/decentralized_identity) for people, organizations, or
+any object in a GDPR-compliant, cost-efficient, and privacy-enabling manner.
+
+## Layer 2
+
+### Smart Contracts
+
+The [IOTA Smart Contracts (ISC)](/smart-contracts/overview) bring scalable, flexible, and cost-effective smart
+contract functionality to the IOTA ecosystem. By anchoring multiple chains to the IOTA Tangle, ISC enables
+higher throughput and lower fees than traditional single-chain solutions. Users have the freedom to create custom
+chains with control over gas fees and privacy settings, and the platform is virtual machine-agnostic, supporting both
+[Rust/Wasm](/smart-contracts/guide/wasm_vm/intro) and [Solidity/EVM](/smart-contracts/guide/evm/introduction)
+smart contracts.

--- a/docs/build/wasp/0.7.0/docs/guide/wasm_vm/intro.mdx
+++ b/docs/build/wasp/0.7.0/docs/guide/wasm_vm/intro.mdx
@@ -16,13 +16,13 @@ description: IOTA Smart Contracts (ISC) provides a very flexible way of programm
 image: /img/wasm_vm/IscHost.png
 ---
 
+# Introduction to the Wasm VM for ISC
+
 :::warning
 The Wasm VM is still in an experimental state, it is a testament to the "VM plugin" architecture of ISC.
 
 Experiment away, but please don't rely on it for any valuable applications (stick to EVM for now).
 :::
-
-# Introduction to the Wasm VM for ISC
 
 IOTA Smart Contracts (ISC) provides a very flexible way of programming smart contracts by
 providing an API to a sandboxed environment that allows you to interact deterministically

--- a/docs/maintain/getting-started/sidebars.ts
+++ b/docs/maintain/getting-started/sidebars.ts
@@ -1,0 +1,3 @@
+module.exports = {
+  maintain: ['welcome'],
+};

--- a/docs/maintain/getting-started/welcome.md
+++ b/docs/maintain/getting-started/welcome.md
@@ -1,0 +1,32 @@
+# Welcome
+
+Welcome to the "Maintain" section of the IOTA wiki. This section will help you set up and maintain IOTA node software
+and INX plugins.
+
+## Layer 1
+
+### Hornet
+
+[Hornet](/hornet/welcome) is a lightweight IOTA node written in Go. It's essential for maintaining the
+IOTA network as it is made entirely of Hornet nodes. You can use the documentation to
+[set up](/hornet/how_tos/using_docker) and
+[configure](/hornet/how_tos/post_installation) your node.
+
+### Chronicle
+
+[Chronicle](/chronicle/welcome) is a permanode solution that allows you to store and retrieve IOTA
+messages and data in real time.
+
+### GoShimmer
+
+[GoShimmer](/goshimmer/welcome) is an experimental node software for IOTA's Coordicide aimed at
+removing the Coordinator from the IOTA networks.
+
+## Layer 2
+
+### WASP - IOTA Smart Contracts
+
+[WASP](/wasp/running-a-node) is an INX plugin you can install and use to run your smart contract chain.
+You can use the documentation to get your node up and running, and [set up](/wasp/setting-up-a-chain) and
+[manage](/wasp/chain-management) a chain, or check out the available
+[configuration options](/wasp/configuration).

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -44,12 +44,12 @@ module.exports = async () => {
           },
           {
             label: 'Learn',
-            to: '/learn/protocols/chrysalis/introduction',
+            to: '/learn/protocols/introduction',
             activeBaseRegex: '^(/[^/]+)?/learn/.*',
           },
           {
             label: 'Build',
-            to: '/build/networks-endpoints/',
+            to: '/build/welcome/',
             activeBaseRegex:
               '^(/[^/]+)?/iota-sdk/.*|' +
               '^(/[^/]+)?/build/.*|' +
@@ -63,7 +63,7 @@ module.exports = async () => {
           },
           {
             label: 'Maintain',
-            to: '/hornet/2.0.0-rc.6/welcome',
+            to: '/maintain/welcome',
             activeBaseRegex:
               '^(/[^/]+)?/hornet/.*|' +
               '^(/[^/]+)?/wasp/.*|' +

--- a/src/components/HomeLayout/AppLibrariesSection.tsx
+++ b/src/components/HomeLayout/AppLibrariesSection.tsx
@@ -51,23 +51,12 @@ const LibrariesSection: FC = () => (
           />
         </div>
         <h3 className='libraries__header'>Identity</h3>
-        <ul className='libraries__features'>
-          <li className='libraries__feature'>
-            <Link to='/identity.rs/decentralized_identity'>
-              Decentralized Identities (SSI)
-            </Link>
-          </li>
-          <li className='libraries__feature'>
-            <Link to='/identity.rs/concepts/decentralized_identifiers/overview'>
-              Decentralized Identifiers (DID)
-            </Link>
-          </li>
-          <li className='libraries__feature'>
-            <Link to='/identity.rs/concepts/verifiable_credentials/overview'>
-              Verifiable Credentials (VC)
-            </Link>
-          </li>
-        </ul>
+        <p className='libraries__feature'>
+          The IOTA Identity framework serves as a unifying layer of trust by
+          implementing common standards for Decentralized Identity that work
+          across various DLTs as well as IOTA-specific methods, catering to
+          individuals, organizations, and objects.
+        </p>
         <Link
           to='/identity.rs/introduction'
           className='libraries__button button button--outline button--primary'
@@ -89,16 +78,11 @@ const LibrariesSection: FC = () => (
           />
         </div>
         <h3 className='libraries__header'>Streams</h3>
-        <ul className='libraries__features'>
-          <li className='libraries__feature'>
-            <Link to='/streams/getting_started'>
-              Organize and share data securely
-            </Link>
-          </li>
-          <li className='libraries__feature'>
-            <Link to='/streams/specs'>Read the specification</Link>
-          </li>
-        </ul>
+        <p className='libraries__feature'>
+          The IOTA Streams framework provides a secure protocol for message
+          verification and protection using the Channels protocol for flexible
+          structuring of channels, publishers and subscribers.
+        </p>
         <Link
           to='/streams/welcome'
           className='libraries__button button button--outline button--primary'
@@ -120,23 +104,12 @@ const LibrariesSection: FC = () => (
           />
         </div>
         <h3 className='libraries__header'>Stronghold</h3>
-        <ul className='libraries__features'>
-          <li className='libraries__feature'>
-            <Link to='/stronghold.rs/how_tos/cli/store_read_write'>
-              Read and write to the vault
-            </Link>
-          </li>
-          <li className='libraries__feature'>
-            <Link to='/stronghold.rs/how_tos/cli/read_snapshot'>
-              Manage snapshots
-            </Link>
-          </li>
-          <li className='libraries__feature'>
-            <Link to='/stronghold.rs/explanations/non-contiguous-data-types'>
-              Learn about non-contiguous data types
-            </Link>
-          </li>
-        </ul>
+        <p className='libraries__feature'>
+          Stronghold is an open-source library designed to securely protect
+          digital secrets like IOTA Seeds and private keys, serving as a
+          cryptographic database that adheres to best practices without
+          revealing sensitive information.
+        </p>
         <Link
           to='/stronghold.rs/getting_started'
           className='libraries__button button button--outline button--primary'
@@ -157,9 +130,11 @@ const LibrariesSection: FC = () => (
           </div>
         </div>
         <h3 className='libraries__header'>IOTA Smart Contracts</h3>
-        <p className='libraries__body'>
+        <p className='libraries__feature'>
           The IOTA Smart Contracts Protocol brings scalable and flexible smart
-          contracts into the IOTA ecosystem.
+          contracts into the IOTA ecosystem. With control over gas fees and
+          privacy settings, supporting both Rust/Wasm and Solidity/EVM smart
+          contracts.
         </p>
         <div className='start-building__buttons'>
           <Link
@@ -168,12 +143,6 @@ const LibrariesSection: FC = () => (
           >
             Learn about ISC
           </Link>
-          {/* <Link
-            to='/smart-contracts/guide/evm/examples/introduction'
-            className='start-building__button button button--primary'
-          >
-            Run a smart contract
-          </Link> */}
         </div>
       </div>
     </div>

--- a/src/components/HomeLayout/CoreLibrariesSection.tsx
+++ b/src/components/HomeLayout/CoreLibrariesSection.tsx
@@ -48,23 +48,10 @@ const LibrariesSection: FC = () => (
           />
         </div>
         <h3 className='libraries__feature'>IOTA SDK</h3>
-        <ul className='libraries__feature'>
-          <li className='libraries__feature'>
-            <Link to='/iota-sdk/how-tos/accounts-and-addresses/create-address'>
-              Create an address
-            </Link>
-          </li>
-          <li className='libraries__feature'>
-            <Link to='/iota-sdk/how-tos/simple-transaction'>
-              Send a transaction
-            </Link>
-          </li>
-          <li className='libraries__feature'>
-            <Link to='/iota-sdk/how-tos/outputs/features'>
-              Test the latest output features
-            </Link>
-          </li>
-        </ul>
+        <p>
+          The IOTA SDK provides a convenient and efficient way to interact with
+          nodes in the Shimmer and IOTA networks running the Stardust protocol.
+        </p>
         <Link
           to='/iota-sdk/welcome'
           className='nodes__button button button--outline button--primary'

--- a/src/components/HomeLayout/index.tsx
+++ b/src/components/HomeLayout/index.tsx
@@ -133,18 +133,12 @@ export default function HomeLayout() {
               </div>
               <div className='nodes__section'>
                 <h3 className='nodes__header'>Hornet</h3>
-                <ul className='nodes__features'>
-                  <li className='nodes__feature'>
-                    <Link to='/hornet/welcome'>
-                      A node implementation written in Go
-                    </Link>
-                  </li>
-                  <li className='nodes__feature'>
-                    <Link to='/hornet/getting_started'>
-                      Participate in the network
-                    </Link>
-                  </li>
-                </ul>
+                <p className='libraries__feature'>
+                  Hornet is an easy-to-install node software that offers full
+                  node capabilities and network updates, granting you direct
+                  access to the IOTA network and contributing to its resilience
+                  by validating messages and transactions.
+                </p>
                 <Link
                   to='/hornet/how_tos/using_docker'
                   className='nodes__button button button--outline button--primary'
@@ -159,23 +153,10 @@ export default function HomeLayout() {
               </div>
               <div className='nodes__section'>
                 <h3 className='nodes__header'>Wasp</h3>
-                <ul className='nodes__features'>
-                  <li className='nodes__feature'>
-                    <Link to='/learn/smart-contracts/core_concepts/validators'>
-                      Validate smart contracts
-                    </Link>
-                  </li>
-                  <li className='nodes__feature'>
-                    <Link to='/smart-contracts/guide/chains_and_nodes/running-a-node'>
-                      Run the Shimmer Smart Contract Protocol
-                    </Link>
-                  </li>
-                  <li className='nodes__feature'>
-                    <Link to='/smart-contracts/guide/evm/introduction'>
-                      Run EVM/Solidity Smart Contract
-                    </Link>
-                  </li>
-                </ul>
+                <p className='libraries__feature'>
+                  WASP is an INX plugin you can install and use to run your
+                  smart contract chain using the IOTA Smart Contracts protocol.
+                </p>
                 <Link
                   to='/smart-contracts/guide/chains_and_nodes/running-a-node'
                   className='nodes__button button button--outline button--primary'
@@ -190,23 +171,10 @@ export default function HomeLayout() {
               </div>
               <div className='nodes__section'>
                 <h3 className='nodes__header'>Chronicle</h3>
-                <ul className='nodes__features'>
-                  <li className='nodes__feature'>
-                    <Link to='/chronicle/welcome'>
-                      Efficient and reliable permanodes
-                    </Link>
-                  </li>
-                  <li className='nodes__feature'>
-                    <Link to='/chronicle/welcome#project-structure'>
-                      Solution for storing all transactions
-                    </Link>
-                  </li>
-                  <li className='nodes__feature'>
-                    <Link to='/chronicle/config_reference'>
-                      Managing and accessing the permanode
-                    </Link>
-                  </li>
-                </ul>
+                <p className='libraries__feature'>
+                  Chronicle is a permanode solution that allows you to store and
+                  retrieve IOTA messages and data in real time.
+                </p>
                 <Link
                   to='chronicle/getting_started'
                   className='nodes__button button button--outline button--primary'

--- a/src/components/HomeLayout/styles.css
+++ b/src/components/HomeLayout/styles.css
@@ -372,7 +372,6 @@
 
 .libraries__section {
   flex: 1 1 0;
-  aspect-ratio: 1/1;
   display: flex;
   flex-direction: column;
 }
@@ -678,4 +677,8 @@
   .spaceholder__card__img {
     display: none;
   }
+}
+
+p.libraries__feature {
+  flex-grow: 1;
 }

--- a/src/switcher.config.ts
+++ b/src/switcher.config.ts
@@ -53,7 +53,7 @@ const buildDocs = [
         id: 'identity-rs-0-5',
         label: '0.5',
         badges: ['IOTA'],
-      }
+      },
     ],
   },
   {
@@ -112,7 +112,7 @@ const buildDocs = [
         id: 'iota-rs-1-4-0',
         label: '1.4.0',
         badges: ['IOTA'],
-      }
+      },
     ],
   },
   {
@@ -145,7 +145,7 @@ const buildDocs = [
         id: 'wallet-rs-0-1-0',
         label: '0.1.0',
         badges: ['IOTA'],
-      }
+      },
     ],
   },
   {
@@ -195,7 +195,7 @@ const maintainDocs = [
         id: 'hornet-1-2-4',
         label: '1.2.4',
         badges: ['IOTA'],
-      }
+      },
     ],
   },
   {
@@ -269,6 +269,10 @@ const config: Config = {
       ],
     },
     {
+      before: {
+        docId: 'maintain',
+        sidebarId: 'maintain',
+      },
       subsections: [
         {
           label: 'Layer 1',


### PR DESCRIPTION
# Description of change

* added intro pages for build and maintain
* corrected header for wasm_vm/intro
* replaced ul links for p with project description for the home page cards
* fixed CSS to get all home page cards to behave in the same manner (no overflow and aciton button at the bottom)

## Links to any relevant issues

fixes https://github.com/iotaledger/devx/issues/205
fixes https://github.com/iotaledger/devx/issues/206

## Type of change

- Documentation Enhancement

## Change checklist

- [x] I have followed the [contribution guidelines](https://github.com/iota-wiki/iota-wiki/blob/main/.github/CONTRIBUTING.md) for this project
- [x] I have performed a self-review of my own changes
- [x] I have made sure that added/changed links still work
- [x] I have commented my code, particularly in hard-to-understand areas
