### PR TITLE
Fix explorer link

### DIFF
--- a/docs/get-started/sidebars.ts
+++ b/docs/get-started/sidebars.ts
@@ -81,7 +81,7 @@ module.exports = {
         {
           type: 'link',
           label: 'Shimmer Explorer',
-          href: 'https://explorer.chrysalis.network/',
+          href: 'https://explorer.shimmer.network/',
         },
       ],
     },


### PR DESCRIPTION
# Description of change

Fix link to navigate to the Shimmer explorer.

## Type of change

- Documentation Fix

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the [contribution guidelines](https://github.com/iota-wiki/iota-wiki/blob/main/.github/CONTRIBUTING.md) for this project
- [x] I have performed a self-review of my own changes
- [x] I have made sure that added/changed links still work
