### PR TITLE
Add version redirects to current version

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -375,6 +375,16 @@ module.exports = async () => {
                 },
               ];
 
+              // Version redirects are only used to asign path with the actual version it to the "current" version
+              const versionRedirects = [
+                {
+                  from: '/identity.rs/0.6',
+                  to: '/identity.rs',
+                },
+              ];
+
+              redirects.push(...versionRedirects);
+
               for (const redirect of redirects) {
                 if (existingPath.includes(redirect.to)) {
                   return existingPath.replace(redirect.to, redirect.from);

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -9,7 +9,9 @@ const {
   buildPluginsConfig,
   maintainPluginsConfig,
 } = require('./versionedConfig');
-const { createMainVersionRedirects } = require('./src/utils/pluginConfigGenerators');
+const {
+  createMainVersionRedirects,
+} = require('./src/utils/pluginConfigGenerators');
 
 module.exports = async () => {
   const contentPlugins = await Promise.all(
@@ -18,9 +20,11 @@ module.exports = async () => {
     ).map(async (contentConfig) => await create_doc_plugin(contentConfig)),
   );
 
-
-  const buildMainVersionRedirects = createMainVersionRedirects(buildPluginsConfig);
-  const maintainMainVersionRedirects = createMainVersionRedirects(maintainPluginsConfig);
+  const buildMainVersionRedirects =
+    createMainVersionRedirects(buildPluginsConfig);
+  const maintainMainVersionRedirects = createMainVersionRedirects(
+    maintainPluginsConfig,
+  );
 
   // Get tutorials
   const additionalPlugins = await glob(['tutorials']);

--- a/src/utils/pluginConfigGenerators.js
+++ b/src/utils/pluginConfigGenerators.js
@@ -68,10 +68,9 @@ function generatePluginConfig(pluginConfig, basePath) {
  * @returns {Array} - An array of redirects.
  */
 function createMainVersionRedirects(versionedConfig) {
-  redirects = []
+  redirects = [];
   for (const doc of versionedConfig) {
-    if (doc.versions.length > 1){
-
+    if (doc.versions.length > 1) {
       // Find main version
       const mainVersion = findMainVersion(doc);
 

--- a/src/utils/pluginConfigGenerators.js
+++ b/src/utils/pluginConfigGenerators.js
@@ -63,6 +63,32 @@ function generatePluginConfig(pluginConfig, basePath) {
 }
 
 /**
+ * Generate directs versioned links to the main version.
+ * @param {import('../common/components/Switcher').Doc[]} versionedConfig - An array of versioned plugin configurations.
+ * @returns {Array} - An array of redirects.
+ */
+function createMainVersionRedirects(versionedConfig) {
+  redirects = []
+  for (const doc of versionedConfig) {
+    if (doc.versions.length > 1){
+
+      // Find main version
+      const mainVersion = findMainVersion(doc);
+
+      // TODO: This could be removed once we don't use points in paths anymore.
+      const routeBasePath = doc.routeBasePath ? doc.routeBasePath : doc.id;
+
+      redirects.push({
+        from: '/' + routeBasePath + '/' + mainVersion.label,
+        to: '/' + routeBasePath,
+      });
+    }
+  }
+
+  return redirects;
+}
+
+/**
  * Generate the switcher config from the versioned config.
  * @param {import('../common/components/Switcher').Doc[]} pluginConfig
  */
@@ -89,4 +115,5 @@ function generateSwitcherConfig(pluginConfig) {
 module.exports = {
   generatePluginConfig,
   generateSwitcherConfig,
+  createMainVersionRedirects,
 };


### PR DESCRIPTION
# Description of change

This PR adds version redirects so that the current version is not only accessible from `/<project>/**` but also from `/<project>/<current-version>/**`

## Links to any relevant issues

Fixes #1086.

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## Change checklist

- [x] I have followed the [contribution guidelines](https://github.com/iota-wiki/iota-wiki/blob/main/.github/CONTRIBUTING.md) for this project
- [x] I have performed a self-review of my own changes
- [x] I have made sure that added/changed links still work
- [x] I have commented my code, particularly in hard-to-understand areas
