### PR TITLE
Add TIPs config

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -12,8 +12,8 @@ module.exports = async () => {
     ).map(async (contentConfig) => await create_doc_plugin(contentConfig)),
   );
 
-  // Get tips and tutorials
-  const additionalPlugins = await glob(['docs/external/tips', 'tutorials']);
+  // Get tutorials
+  const additionalPlugins = await glob(['tutorials']);
 
   const { MODE = 'development' } = process.env;
 
@@ -160,6 +160,38 @@ module.exports = async () => {
       ],
       plugins: [
         ...contentPlugins,
+        [
+          '@docusaurus/plugin-content-docs',
+          {
+            id: 'iota-tips',
+            path: path.resolve(__dirname, './docs/external/tips'),
+            routeBasePath: 'tips',
+            editUrl: ({ docPath }) =>
+              `https://github.com/iotaledger/tips/edit/main/${docPath}`,
+            remarkPlugins: [require('remark-import-partial')],
+            include: ['tips/**/*.md', 'README.md'],
+
+            // Create own sidebar to flatten hierarchy and use own labeling
+            async sidebarItemsGenerator({
+              defaultSidebarItemsGenerator,
+              ...args
+            }) {
+              const items = await defaultSidebarItemsGenerator(args);
+
+              const result = items[1].items.map((item) => {
+                if (item.type === 'category') {
+                  if (item.link.type === 'doc') {
+                    // Get TIP number and append TIP name
+                    item.label = item.link.id.slice(-4) + '-' + item.label;
+                  }
+                }
+                return item;
+              });
+
+              return [items[0]].concat(result);
+            },
+          },
+        ],
         [
           'docusaurus-plugin-openapi-docs',
           {


### PR DESCRIPTION
# Description of change

With the decision to move almost all docs to the Wiki, we might as well move the TIPs config to this repo. The advantages being all Wiki configuration is contained in the Wiki repo and the TIPs repo can be cleaned up by removing anything Docusaurus and package management related.

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the [contribution guidelines](https://github.com/iota-wiki/iota-wiki/blob/main/.github/CONTRIBUTING.md) for this project
- [x] I have performed a self-review of my own changes
- [x] I have made sure that added/changed links still work
