### PR TITLE
Refactor preparation of workflows

### DIFF
--- a/.github/actions/prepare/action.yaml
+++ b/.github/actions/prepare/action.yaml
@@ -27,4 +27,4 @@ runs:
       uses: actions/cache@v3
       with:
         path: node_modules/.cache
-        key: wiki-build-artifacts-${{ hashFiles('package.json', 'yarn.lock', 'src/**/*.*') }}
+        key: wiki-build-artifacts

--- a/.github/actions/prepare/action.yaml
+++ b/.github/actions/prepare/action.yaml
@@ -1,5 +1,5 @@
 name: prepare
-description: Prepare environment for building the Wiki
+description: Prepare Yarn and caches
 
 runs:
   using: 'composite'
@@ -8,8 +8,7 @@ runs:
       with:
         node-version: 16
     - name: Allow modern Yarn
-      run: |
-        corepack enable
+      run: corepack enable
       shell: bash
     # Dependencies manually cached because `actions/setup-node@v3` does not support corepack
     - name: Cache dependencies
@@ -21,12 +20,7 @@ runs:
         restore-keys: |
           wiki-dependencies
     - name: Install dependencies
-      run: |
-        yarn
-      shell: bash
-    - name: Prepare build
-      run: |
-        yarn prepare
+      run: yarn
       shell: bash
     # Artifacts cached after install to prevent removal by Yarn
     - name: Cache build artifacts

--- a/.github/workflows/clear.yml
+++ b/.github/workflows/clear.yml
@@ -24,6 +24,8 @@ jobs:
           ref: ${{ github.event.issue.pull_request && format('refs/pull/{0}/merge', github.event.issue.number) || '' }}
       - name: Prepare Yarn
         uses: ./.github/actions/prepare/
+      - name: Clear Docusaurus build cache
+        run: yarn clear
       - name: Prepare build
         run: yarn prepare
         shell: bash

--- a/.github/workflows/clear.yml
+++ b/.github/workflows/clear.yml
@@ -1,0 +1,44 @@
+name: clear
+
+on:
+  workflow_dispatch:
+  issue_comment:
+    types: [created]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.issue.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  clear:
+    if: |
+      github.event_name == 'workflow_dispatch' ||
+      (
+        github.event.issue.pull_request && 
+        contains(github.event.comment.body, '/clear-build')
+      )
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.issue.pull_request && format('refs/pull/{0}/merge', github.event.issue.number) || '' }}
+      - name: Prepare Yarn
+        uses: ./.github/actions/prepare/
+      - name: Prepare build
+        run: yarn prepare
+        shell: bash
+      - name: Build
+        run: yarn build
+      # Create a comment on the pull request that the clear build completed
+      - name: Comment on pull request
+        if: github.event_name != 'workflow_dispatch'
+        uses: actions/github-script@v6.4.0
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: `Clear build has completed and caches have been renewed.`
+            })

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,7 +1,9 @@
 name: deploy
+
 env:
   VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
   VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+
 on:
   workflow_dispatch:
   schedule:
@@ -17,8 +19,11 @@ jobs:
         with:
           # Needed for showLastUpdateTime to work
           fetch-depth: 0
-      - name: Prepare
+      - name: Prepare Yarn
         uses: ./.github/actions/prepare/
+      - name: Prepare build
+        run: yarn prepare
+        shell: bash
       - name: Checkout remote
         run: yarn checkout:remote
       - name: Build

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,7 +1,9 @@
 name: preview
+
 env:
   VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
   VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+
 on:
   workflow_dispatch:
   pull_request:
@@ -33,8 +35,11 @@ jobs:
       - uses: actions/checkout@v3
         with:
           ref: ${{ github.event.issue.pull_request && format('refs/pull/{0}/merge', github.event.issue.number) || '' }}
-      - name: Prepare
+      - name: Prepare Yarn
         uses: ./.github/actions/prepare/
+      - name: Prepare build
+        run: yarn prepare
+        shell: bash
       - name: Build
         run: yarn build
       # Convert to Vercel project and upload

--- a/.github/workflows/publish.reusable.yaml
+++ b/.github/workflows/publish.reusable.yaml
@@ -1,4 +1,5 @@
 name: publish package
+
 on:
   workflow_call:
     inputs:
@@ -10,6 +11,7 @@ on:
         description: 'Workspace name'
         required: true
         type: string
+
 jobs:
   check:
     # TODO: Output `changed: true` only when version is higher than previous, not just changed
@@ -42,20 +44,11 @@ jobs:
     if: needs.check.outputs.changed != 'true'
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
-        with:
-          node-version: 16
-          cache: 'yarn'
-      - name: Allow modern Yarn
-        run: |
-          corepack enable
-      - name: Install dependencies
-        run: |
-          yarn
+      - name: Prepare Yarn
+        uses: ./.github/actions/prepare/
       # Test if packaging will succeed
       - name: Pack
-        run: |
-          yarn workspace ${{ inputs.workspace }} pack --dry-run
+        run: yarn workspace ${{ inputs.workspace }} pack --dry-run
   publish:
     runs-on: ubuntu-latest
     needs:
@@ -63,25 +56,15 @@ jobs:
     if: needs.check.outputs.changed == 'true'
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
-        with:
-          node-version: 16
-          cache: 'yarn'
-      - name: Allow modern Yarn
-        run: |
-          corepack enable
-      - name: Install dependencies
-        run: |
-          yarn
+      - name: Prepare Yarn
+        uses: ./.github/actions/prepare/
       - name: Publish to NPM
-        run: |
-          yarn workspace ${{ inputs.workspace }} npm publish --access public --tag experimental
+        run: yarn workspace ${{ inputs.workspace }} npm publish --access public --tag experimental
         env:
           YARN_NPM_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           YARN_NPM_REGISTRY_SERVER: 'https://registry.npmjs.org'
       - name: Publish to GitHub
-        run: |
-          yarn workspace ${{ inputs.workspace }} npm publish --access public --tag experimental
+        run: yarn workspace ${{ inputs.workspace }} npm publish --access public --tag experimental
         env:
           YARN_NPM_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           YARN_NPM_REGISTRY_SERVER: 'https://npm.pkg.github.com'

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,4 +1,5 @@
 name: publish packages
+
 on:
   workflow_dispatch:
   pull_request:

--- a/.github/workflows/tag.reusable.yaml
+++ b/.github/workflows/tag.reusable.yaml
@@ -1,4 +1,5 @@
 name: tag package
+
 on:
   workflow_call:
     inputs:
@@ -10,6 +11,7 @@ on:
         description: 'Workspace name'
         required: true
         type: string
+
 jobs:
   check:
     # TODO: Output `changed: true` only when version is higher than previous, not just changed
@@ -35,25 +37,15 @@ jobs:
     if: needs.check.outputs.changed == 'true'
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
-        with:
-          node-version: 16
-          cache: 'yarn'
-      - name: Allow modern Yarn
-        run: |
-          corepack enable
-      - name: Install dependencies
-        run: |
-          yarn
+      - name: Prepare Yarn
+        uses: ./.github/actions/prepare/
       - name: Tag on NPM
-        run: |
-          yarn npm tag add ${{ inputs.workspace }}@${{ needs.check.outputs.version }} latest
+        run: yarn npm tag add ${{ inputs.workspace }}@${{ needs.check.outputs.version }} latest
         env:
           YARN_NPM_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           YARN_NPM_REGISTRY_SERVER: 'https://registry.npmjs.org'
       - name: Tag on GitHub
-        run: |
-          yarn npm tag add ${{ inputs.workspace }}@${{ needs.check.outputs.version }} latest
+        run: yarn npm tag add ${{ inputs.workspace }}@${{ needs.check.outputs.version }} latest
         env:
           YARN_NPM_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           YARN_NPM_REGISTRY_SERVER: 'https://npm.pkg.github.com'

--- a/.github/workflows/tag.yaml
+++ b/.github/workflows/tag.yaml
@@ -1,9 +1,11 @@
 name: tag packages
+
 on:
   workflow_dispatch:
   push:
     branches:
       - main
+
 jobs:
   tag:
     strategy:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,28 +15,21 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
-        with:
-          node-version: 16
-          cache: 'yarn'
-      - name: Allow modern Yarn
-        run: |
-          corepack enable
-      - name: Install dependencies
-        run: |
-          yarn
+      - name: Prepare Yarn
+        uses: ./.github/actions/prepare/
       - name: Lint Wiki
-        run: |
-          yarn lint:check
+        run: yarn lint:check
       - name: Format Wiki
-        run: |
-          yarn format:check
+        run: yarn format:check
   build:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Prepare
+      - name: Prepare Yarn
         uses: ./.github/actions/prepare/
+      - name: Prepare build
+        run: yarn prepare
+        shell: bash
       - name: Checkout remote
         run: yarn checkout:remote
       - name: Build


### PR DESCRIPTION
# Description of change

- Refactored the `prepare` action to only set up Yarn and create the dependency and build caches.
- Removed the `yarn prepare` call from the `prepare` action, to explicitly call it only in actions that require it.
- Added the `prepare` action to the `consistency` job, to speed it up.
- Changed the build caching to always restore and added a `clear` workflow that we can manually trigger through a dispatch or by commenting `/clear-build` on a PR, to renew Docusaurus build caches when needed.

## Links to any relevant issues

#1122

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the [contribution guidelines](https://github.com/iota-wiki/iota-wiki/blob/main/.github/CONTRIBUTING.md) for this project
- [x] I have performed a self-review of my own changes
- [x] I have commented my code, particularly in hard-to-understand areas
