### PR TITLE
Fix relative urls by using relative paths

### DIFF
--- a/docs/build/wasp-evm/0.7/docs/explanations/how-accounts-work.md
+++ b/docs/build/wasp-evm/0.7/docs/explanations/how-accounts-work.md
@@ -63,7 +63,7 @@ The Agent ID of the common account is `<hname=0>@<address zero (0x00000...)>`.
 
 ### Ethereum Address
 
-An L2 account can also be owned by an Ethereum address. See [EVM](/wasp-evm/introduction/) for more information.
+An L2 account can also be owned by an Ethereum address. See [EVM](../introduction.md) for more information.
 The Agent ID of an Ethereum address is just the address prefixed with `0x`,
 e.g. `0xd36722adec3edcb29c8e7b5a47f352d701393462`.
 

--- a/docs/build/wasp-evm/0.7/docs/getting-started/compatibility.md
+++ b/docs/build/wasp-evm/0.7/docs/getting-started/compatibility.md
@@ -14,7 +14,7 @@ keywords:
 
 # EVM Compatibility in IOTA Smart Contracts
 
-The [`evm`](/wasp-wasm/reference/core-contracts/evm) [core contract](/wasp-wasm/reference/core-contracts/overview)
+The [`evm`](../reference/core-contracts/evm.md) [core contract](../reference/core-contracts/overview.md)
 provides EVM support in IOTA Smart Contracts. It stores the EVM state (account balances, state, code,
 etc.) and provides a way to execute EVM code to manipulate the state.
 
@@ -53,7 +53,7 @@ identified by their Ethereum address.
 
 ### WASM Root Contract List
 
-EVM contracts are not listed in the chain's [contract registry](/wasp-wasm/reference/core-contracts/root).
+EVM contracts are not listed in the chain's [contract registry](../reference/core-contracts/root.md).
 
 ### On-ledger Requests
 
@@ -66,7 +66,7 @@ Unlike Ethereum's blockchain that houses the state in a Merkle tree, the EVM sta
 duplication of efforts undertaken by the ISC layer.
 
 Any Ethereum transactions present in an ISC block are executed by
-the [`evm`](/wasp-wasm/reference/core-contracts/evm) [core contract](/wasp-wasm/reference/core-contracts/overview),
+the [`evm`](../reference/core-contracts/evm.md) [core contract](../reference/core-contracts/overview.md),
 updating the EVM state accordingly. An emulated Ethereum block is also created and stored to provide compatibility
 with EVM tools. As the emulated block is not part of a real Ethereum blockchain, some attributes of the blocks will
 contain dummy values (e.g. `stateRoot`, `nonce`, etc.).

--- a/docs/build/wasp-evm/0.7/docs/how-tos/magic-contract/magic.md
+++ b/docs/build/wasp-evm/0.7/docs/how-tos/magic-contract/magic.md
@@ -22,7 +22,7 @@ functionality through the \_[ISC Magic Contract](../../reference/magic-contract.
 The Magic contract is an EVM contract deployed by default on every ISC chain, in the EVM genesis block, at
 address `0x1074000000000000000000000000000000000000`.
 The implementation of the Magic contract is baked-in in
-the [`evm`](/wasp-wasm/reference/core-contracts/evm) [core contract](/wasp-wasm/reference/core-contracts/overview);
+the [`evm`](../../reference/core-contracts/evm.md) [core contract](../../reference/core-contracts/overview.md);
 i.e. it is not a pure-Solidity contract.
 
 The Magic contract has several methods, which are categorized into specialized

--- a/docs/build/wasp-evm/0.7/docs/introduction.md
+++ b/docs/build/wasp-evm/0.7/docs/introduction.md
@@ -43,7 +43,7 @@ changes to function on IOTA Smart Contracts.
 ### How IOTA Smart Contracts Work With EVM
 
 Every deployed IOTA Smart Contracts chain automatically includes a core contract
-called [`evm`](/wasp-wasm/reference/core-contracts/evm/). This core contract is responsible for running EVM code and
+called [`evm`](./reference/core-contracts/evm.md). This core contract is responsible for running EVM code and
 storing the EVM state.
 
 The Wasp node also provides a standard JSON-RPC service, which allows you to interact with the EVM layer using existing

--- a/docs/build/wasp-evm/0.7/docs/reference/core-contracts/evm.md
+++ b/docs/build/wasp-evm/0.7/docs/reference/core-contracts/evm.md
@@ -20,11 +20,11 @@ keywords:
 The `evm` contract is one of the [core contracts](overview.md) on each IOTA Smart Contracts chain.
 
 The `evm` core contract provides the necessary infrastructure to accept Ethereum transactions and execute EVM code.
-It also includes the implementation of the [ISC Magic contract](/wasp-evm/how-tos/magic-contract/magic).
+It also includes the implementation of the [ISC Magic contract](../../how-tos/magic-contract/magic.md).
 
 :::note
 
-For more information about how ISC supports EVM contracts, refer to the [EVM](/wasp-evm/introduction/) section.
+For more information about how ISC supports EVM contracts, refer to the [EVM](../../introduction.md) section.
 
 :::
 

--- a/docs/build/wasp-evm/0.7/docs/reference/magic-contract.md
+++ b/docs/build/wasp-evm/0.7/docs/reference/magic-contract.md
@@ -14,20 +14,20 @@
 - [ERC20NativeTokens](https://github.com/iotaledger/wasp/blob/develop/packages/vm/core/evm/iscmagic/ERC20NativeTokens.sol)
   contract, available at `ISC.nativeTokens(foundrySN)` after being registered
   by the foundry owner by calling
-  [`registerERC20NativeToken`](/wasp-wasm/reference/core-contracts/evm#registerERC20NativeToken)
+  [`registerERC20NativeToken`](./core-contracts/evm.md#registerERC20NativeToken)
   (address `0x107402xxxxxxxx00000000000000000000000000` where `xxxxxxxx` is the
   little-endian encoding of the foundry serial number)
 - [ERC20ExternalNativeTokens](https://github.com/iotaledger/wasp/blob/develop/packages/vm/core/evm/iscmagic/ERC20ExternalNativeTokens.sol)
   contract, available at a dynamically assigned address after being registered
   by the foundry owner by calling
-  [`registerERC20NativeTokenOnRemoteChain`](/wasp-wasm/reference/core-contracts/evm#registerERC20NativeTokenOnRemoteChain)
+  [`registerERC20NativeTokenOnRemoteChain`](./core-contracts/evm.md#registerERC20NativeTokenOnRemoteChain)
   on the chain that controls the foundry.
 - [ERC721NFTs](https://github.com/iotaledger/wasp/blob/develop/packages/vm/core/evm/iscmagic/ERC721NFTs.sol)
   contract, available at `ISC.nfts`
   (address `0x1074030000000000000000000000000000000000`)
 - [ERC721NFTCollection](https://github.com/iotaledger/wasp/blob/develop/packages/vm/core/evm/iscmagic/ERC721NFTCollection.sol)
   contract, available at `ISC.erc721NFTCollection(collectionID)`, after being
-  registered by calling [`registerERC721NFTCollection`](/wasp-wasm/reference/core-contracts/evm#registerERC721NFTCollection).
+  registered by calling [`registerERC721NFTCollection`](./core-contracts/evm.md#registerERC721NFTCollection).
 
 There are some usage examples in
 the [ISCTest.sol](https://github.com/iotaledger/wasp/blob/develop/packages/evm/evmtest/ISCTest.sol) contract (used


### PR DESCRIPTION
# Description of change

We shouldn't use relative urls inside a plugin. Always use relative paths in that case.
Also as we duplicated the core-contracts we can also link them relative so that we don't link to wasmVM from EVM and vice versa.

## Type of change

- Documentation Fix

## Change checklist

- [x] I have followed the [contribution guidelines](https://github.com/iota-wiki/iota-wiki/blob/main/.github/CONTRIBUTING.md) for this project
- [x] I have performed a self-review of my own changes
- [x] I have made sure that added/changed links still work
- [ ] I have commented my code, particularly in hard-to-understand areas
