### PR TITLE
Let Dependabot ignore dependencies we should update manually

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,11 @@ updates:
     schedule:
       interval: 'monthly'
     ignore:
-      - dependency-name: 'fs-extra'
       - dependency-name: '*'
         update-types: ['version-update:semver-major']
+      - dependency-name: '@docusaurus*'
+      - dependency-name: 'eslint*'
+      - dependency-name: 'prettier*'
+      - dependency-name: 'react'
+      - dependency-name: 'react-dom'
+      - dependency-name: 'fs-extra'


### PR DESCRIPTION
# Description of change

Some packages recommended to pin their versions, like `prettier` and `eslint`. Some packages often introduce build breaking changes that warrant manual updating only when recommended or deemed necessary, like `docusaurus` and `react` packages.

## Links to any relevant issues

fixes #996

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the [contribution guidelines](https://github.com/iota-wiki/iota-wiki/blob/main/.github/CONTRIBUTING.md) for this project
- [x] I have performed a self-review of my own changes
