### PR TITLE
Fix redirects

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -323,7 +323,7 @@ module.exports = async () => {
                 },
                 {
                   from: '/shimmer/hornet',
-                  to: '/hornet/2.0',
+                  to: '/hornet',
                 },
                 {
                   from: '/shimmer/identity.rs',
@@ -391,11 +391,14 @@ module.exports = async () => {
                 },
               ];
 
+              let paths = [];
               for (const redirect of redirects) {
-                if (existingPath.includes(redirect.to)) {
-                  return existingPath.replace(redirect.to, redirect.from);
+                if (existingPath.startsWith(redirect.to)) {
+                  paths.push(existingPath.replace(redirect.to, redirect.from));
                 }
               }
+
+              return paths.length > 0 ? paths : undefined;
             },
           },
         ],


### PR DESCRIPTION
# Description of change

Fixed multiple bugs in redirects:
- Hornet redirects were not correctly created, because for `to: /hornet/2.0` no docs exist so no redirects were created. So I changed it to `to: /hornet`.
- Only the first redirect was returned so now we return an array
- Instead of `includes` I now used `startsWith` to not replace weird occurrences in the middle.

## Type of change

- Bug fix (a non-breaking change which fixes an issue)
- Enhancement (a non-breaking change which adds functionality)

## Change checklist

- [x] I have followed the [contribution guidelines](https://github.com/iota-wiki/iota-wiki/blob/main/.github/CONTRIBUTING.md) for this project
- [x] I have performed a self-review of my own changes
- [x] I have made sure that added/changed links still work
- [x] I have commented my code, particularly in hard-to-understand areas
