### PR TITLE
Adds info box mentioning network resets

### DIFF
--- a/docs/build/getting-started/networks-endpoints.mdx
+++ b/docs/build/getting-started/networks-endpoints.mdx
@@ -122,6 +122,10 @@ Mainnet.
 
 [The Public Testnet](https://explorer.iota.org/testnet) acts as a test bed for builders without any real world value.
 
+:::info
+This network is subject to occasional resets (no data retention) which are usually announced with a one-week grace period.
+:::
+
 <table style={{ wordBreak: 'break-all', verticalAlign: 'middle' }}>
   <tbody>
     <tr>
@@ -161,6 +165,10 @@ Mainnet.
 of the Public Testnet. This network does not run
 any IOTA protocol but instead uses ISC to facilitate an Ethereum Virtual Machine and has an enshrined bridge from to
 layer 1.
+
+:::info
+This network is subject to occasional resets (no data retention) which are usually announced with a one-week grace period.
+:::
 
 <table style={{ wordBreak: 'break-all', verticalAlign: 'middle' }}>
   <tbody>


### PR DESCRIPTION
Clarifies that the Public Testnet and Testnet EVM are subject to occasional resets where no data is retained. It is important that people engaging with those network are aware of this and hence it should be written into the wiki.