### PR TITLE
Add versioning guide to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,10 @@ The IOTA Wiki is maintained by the IF and community contributions are always wel
 
 Have a look at [CONTRIBUTING](.github/CONTRIBUTING.md) for further guidance.
 
+### Versioning
+
+To find out how to version your docs, read [this guide](https://wiki.iota.org/community/contribute-to-wiki/how_tos/versioning).
+
 ### Online one-click setup for contributing
 
 You can use Gitpod (a free, online, VS Code-like IDE) for contributing. With a single click it will prepare everything you need to build and contribute to the Wiki. Just click on this button and skip step 1 from above.


### PR DESCRIPTION
# Description of change

Added a subsection in the README to link to the versioning how-to.
I decided against adding another README in the docs folder for versioning. Although technically possible to have it both in the docs folder and the wiki, it would not make sense locally as in the Wiki the guide has to be written separately, so I think it makes no sense.

## Links to any relevant issues

Fixes https://github.com/iotaledger/devx/issues/272.

## Type of change

- Documentation Enhancement

## Change checklist

- [x] I have followed the [contribution guidelines](https://github.com/iota-wiki/iota-wiki/blob/main/.github/CONTRIBUTING.md) for this project
- [x] I have performed a self-review of my own changes
- [x] I have made sure that added/changed links still work
- [ ] I have commented my code, particularly in hard-to-understand areas
