### PR TITLE
Remove description flag from wasp-cli

### DIFF
--- a/docs/build/wasp-cli/v1.0.0-rc.6/docs/how-tos/setting-up-a-chain.md
+++ b/docs/build/wasp-cli/v1.0.0-rc.6/docs/how-tos/setting-up-a-chain.md
@@ -72,7 +72,7 @@ wasp-cli request-funds
 You can deploy your IOTA Smart Contracts chain by running:
 
 ```shell
-wasp-cli chain deploy --peers=foo,bar,baz --chain=mychain --description="My chain" --block-keep-amount=10000
+wasp-cli chain deploy --peers=foo,bar,baz --chain=mychain --block-keep-amount=10000
 ```
 
 The names in `--peers=foo,bar,baz` correspond to the names of the node's trusted peers.


### PR DESCRIPTION
# Description of change

Seems like the description flag doesn't exist anymore, so I removed it

## Type of change

- Documentation Fix

## Change checklist

- [x] I have followed the [contribution guidelines](https://github.com/iota-wiki/iota-wiki/blob/main/.github/CONTRIBUTING.md) for this project
- [x] I have performed a self-review of my own changes
- [ ] I have made sure that added/changed links still work
- [ ] I have commented my code, particularly in hard-to-understand areas
