### PR TITLE
Fix typos for ISC in Learn section

### DIFF
--- a/docs/learn/smart-contracts/invocation.md
+++ b/docs/learn/smart-contracts/invocation.md
@@ -100,7 +100,7 @@ Any funds sent to the chain via on-ledger requests are credited to the sender's 
 For contracts to use funds owned by the _caller_, the _caller_ must specify an `Allowance` in the request. Contracts can
 then claim any of the allowed funds using the sandbox `TransferAllowedFunds` function.
 
-The Allowance properly looks like the following:
+The Allowance property looks like the following:
 
 ```go
 {

--- a/docs/learn/smart-contracts/smart-contract-anatomy.md
+++ b/docs/learn/smart-contracts/smart-contract-anatomy.md
@@ -37,7 +37,7 @@ The smart contract state is the data owned by the smart contract and stored on t
 The state is a collection of key/value pairs.
 Each key and value are byte arrays of arbitrary size (there are practical limits set by the underlying database, of
 course).
-You can think of the smart contract state as a \_partition of the chain's data state, which can only be written by the
+You can think of the smart contract state as a partition of the chain's data state, which can only be written by the
 smart contract program itself.
 
 The smart contract also owns an _account_ on the chain, stored as part of the chain state.
@@ -59,9 +59,9 @@ An entry point is a function through which you can invoke the program.
 
 There are two types of entry points:
 
-- _Full entry points_(or simply _entry points_): These functions can modify
+- _Full entry points_ (or simply _entry points_): These functions can modify
   (mutate) the smart contract's state.
-- _View entry points_(or _views_): These are read-only functions. They are only used
+- _View entry points_ (or _views_): These are read-only functions. They are only used
   to retrieve the information from the smart contract state. They cannot
   modify the state, i.e., they are read-only calls.
 

--- a/docs/learn/smart-contracts/state_manager.md
+++ b/docs/learn/smart-contracts/state_manager.md
@@ -82,10 +82,10 @@ value must be considerably smaller than `stateManager.pruningMinStatesToKeep`.
 
 ## Obtaining blocks
 
-Requests to state manager contain the state commitment and the state manager must ensure, that block (state) with this
+Requests to the state manager contain the state commitment and the state manager must ensure, that block (state) with this
 commitment is present in the DB. It is possible that to satisfy the request state manager needs to retrieve
 several blocks. However this cannot be done in one step as only the commitment of the requested block is known. For this
-reason state (block) contains a commitment of previous block. Previous block must be committed prior to committing the
+reason state (block) contains a commitment of the previous block. Previous block must be committed prior to committing the
 requested block. And this logic can be extended up to the block, which is already present in the DB, or until the origin
 state is reached.
 

--- a/docs/learn/smart-contracts/validators.md
+++ b/docs/learn/smart-contracts/validators.md
@@ -46,5 +46,4 @@ It is common for validator nodes to be part of a private subnet and have only a 
 outside world, protecting the committee from external attacks.
 
 The management of validator and access nodes is done through
-the [governance core contract](wasp-wasm/reference/core-contracts/
-governance/).
+the [`governance` core contract](/wasp-wasm/reference/core-contracts/governance/).

--- a/docs/learn/smart-contracts/validators.md
+++ b/docs/learn/smart-contracts/validators.md
@@ -46,5 +46,5 @@ It is common for validator nodes to be part of a private subnet and have only a 
 outside world, protecting the committee from external attacks.
 
 The management of validator and access nodes is done through
-the [`governance` core contract](/wasp-wasm/reference/core-contracts/
+the [governance core contract](wasp-wasm/reference/core-contracts/
 governance/).


### PR DESCRIPTION
# Description of change

Fixed some typos for ISC in the Learn section

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Documentation Fix

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the [contribution guidelines](https://github.com/iota-wiki/iota-wiki/blob/main/.github/CONTRIBUTING.md) for this project
- [x] I have performed a self-review of my own changes
- [x] I have made sure that added/changed links still work