### PR TITLE
Update chain ID from 1072 to 1073

### DIFF
--- a/docs/build/getting-started/networks-endpoints.mdx
+++ b/docs/build/getting-started/networks-endpoints.mdx
@@ -80,7 +80,7 @@ This network is subject to occasional resets (no data retention) which are usual
 
 | Base Token                | Protocol  | Chain ID | RPC URL                                      | Faucet                                     | Explorer                                     |
 | ------------------------- | --------- | -------- | -------------------------------------------- | ------------------------------------------ | -------------------------------------------- |
-| Testnet Tokens (no value) | ISC / EVM | 1072     | https://json-rpc.evm.testnet.shimmer.network | https://evm-faucet.testnet.shimmer.network | https://explorer.evm.testnet.shimmer.network |
+| Testnet Tokens (no value) | ISC / EVM | 1073     | https://json-rpc.evm.testnet.shimmer.network | https://evm-faucet.testnet.shimmer.network | https://explorer.evm.testnet.shimmer.network |
 
 ## DevNet
 

--- a/docs/build/wasp-evm/v1.0.0-rc.6/docs/getting-started/compatible-tools.md
+++ b/docs/build/wasp-evm/v1.0.0-rc.6/docs/getting-started/compatible-tools.md
@@ -27,7 +27,7 @@ directly with an IOTA Smart Contracts chain running EVM as long as you take a co
 1. Please make sure you use the correct JSON-RPC endpoint URL in your tooling for your chain. You can find the JSON-RPC
    endpoint URL in the Wasp dashboard (`<URL>/wasp/dashboard` when using `node-docker-setup`).
 2. Please ensure you use the correct `Chain ID` configured while starting the JSON-RPC service. If you did not
-   explicitly define this while starting the service, the default Chain ID will be `1072`.
+   explicitly define this while starting the service, the default Chain ID will be `1073`.
 3. Fees are being handled on the IOTA Smart Contracts chain level, not the EVM level. Because of this, you can simply
    use a gas price of 0 on the EVM level at this time.
 
@@ -67,7 +67,7 @@ For example this would be the config to add the [Public Testnet](/build/networks
 
 - Network Name: `Public Testnet`
 - New RPC URL: `https://json-rpc.evm.testnet.shimmer.network/`
-- Chain ID: `1072`
+- Chain ID: `1073`
 - Currency Symbol: `SMR`
 - Block Explorer URL: `https://explorer.evm.testnet.shimmer.network/`
 
@@ -107,7 +107,7 @@ make sure you add the correct network parameters to your `hardhat.config.js`, fo
 networks: {
     'shimmerevm-testnet': {
       url: 'https://json-rpc.evm.testnet.shimmer.network',
-      chainId: 1072,
+      chainId: 1073,
       accounts: [priv_key],
     },
 }

--- a/docs/build/wasp-wasm/v1.0.0-rc.6/docs/testnet.md
+++ b/docs/build/wasp-wasm/v1.0.0-rc.6/docs/testnet.md
@@ -39,7 +39,7 @@ the following configuration:
 | Key      | Value                                        |
 | -------- | -------------------------------------------- |
 | RPC URL  | https://json-rpc.evm.testnet.shimmer.network |
-| Chain ID | 1072                                         |
+| Chain ID | 1073                                         |
 
 :::note
 

--- a/theme/src/theme/AddToMetaMaskButton/index.tsx
+++ b/theme/src/theme/AddToMetaMaskButton/index.tsx
@@ -9,7 +9,7 @@ declare global {
 
 export const EVMNetworks = {
   'shimmerevm-testnet': {
-    chainId: '0x430',
+    chainId: '0x431',
     chainName: 'ShimmerEVM Testnet',
     nativeCurrency: {
       name: 'Shimmer',

--- a/tutorials/pages/shimmerevm-testnet-hardhat.md
+++ b/tutorials/pages/shimmerevm-testnet-hardhat.md
@@ -132,7 +132,7 @@ module.exports = {
   networks: {
     'shimmerevm-testnet': {
       url: 'https://json-rpc.evm.testnet.shimmer.network',
-      chainId: 1072,
+      chainId: 1073,
       accounts: [priv_key],
     },
   },
@@ -205,7 +205,7 @@ etherscan: {
   customChains: [
     {
       network: 'shimmerevm-testnet',
-      chainId: 1072,
+      chainId: 1073,
       urls: {
         apiURL: 'https://explorer.evm.testnet.shimmer.network/api',
         browserURL: 'https://explorer.evm.testnet.shimmer.network/',

--- a/tutorials/pages/shimmerevm-testnet-setup.mdx
+++ b/tutorials/pages/shimmerevm-testnet-setup.mdx
@@ -22,7 +22,7 @@ To add the ShimmerEVM Testnet network manually to your Metamask use following in
 
 - Network Name: `ShimmerEVM Testnet`
 - New RPC URL: `https://json-rpc.evm.testnet.shimmer.network`
-- Chain ID: `1072`
+- Chain ID: `1073`
 - Currency Symbol: `SMR`
 - Explorer URL: https://explorer.evm.testnet.shimmer.network
 


### PR DESCRIPTION
# Description of change

After the reset the EVM testnet chain ID should now be 1073.

## Type of change

- Documentation Fix

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the [contribution guidelines](https://github.com/iota-wiki/iota-wiki/blob/main/.github/CONTRIBUTING.md) for this project
- [x] I have performed a self-review of my own changes
- [x] I have made sure that added/changed links still work
