### PR TITLE
Fix broken regex in api docs creation

### DIFF
--- a/docs/build/apis/sidebars.js
+++ b/docs/build/apis/sidebars.js
@@ -16,7 +16,7 @@ function resolveSidebarPaths(category) {
 }
 
 function generateDirectoryPath(basePath, label) {
-  const directoryName = label.toLowerCase().replaceAll(/ +/g, '-');
+  const directoryName = label.toLowerCase().replaceAll(/\s+/g, '-');
   const directoryPath = path.join(__dirname, basePath, directoryName);
   return directoryPath;
 }

--- a/docs/build/apis/sidebars.js
+++ b/docs/build/apis/sidebars.js
@@ -16,7 +16,7 @@ function resolveSidebarPaths(category) {
 }
 
 function generateDirectoryPath(basePath, label) {
-  const directoryName = label.toLowerCase().replaceAll(/s+/g, '-');
+  const directoryName = label.toLowerCase().replaceAll(/ +/g, '-');
   const directoryPath = path.join(__dirname, basePath, directoryName);
   return directoryPath;
 }


### PR DESCRIPTION
# Description of change

Replaced the regex which replaced `s` with `-`, to replace whitespaces. I guess this was just a typo? Or am I missing something?

## Links to any relevant issues

Fixes #1346.

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## Change checklist

- [x] I have followed the [contribution guidelines](https://github.com/iota-wiki/iota-wiki/blob/main/.github/CONTRIBUTING.md) for this project
- [x] I have performed a self-review of my own changes
- [x] I have made sure that added/changed links still work
- [ ] I have commented my code, particularly in hard-to-understand areas
