### PR TITLE
Add Mana Calculator to sidebar

### DIFF
--- a/docs/learn/sidebars.ts
+++ b/docs/learn/sidebars.ts
@@ -66,6 +66,7 @@ module.exports = {
                 'protocols/iota2.0/core-concepts/data-flow',
                 'protocols/iota2.0/core-concepts/data-structures',
                 'protocols/iota2.0/core-concepts/mana',
+                'protocols/iota2.0/core-concepts/mana-calculator',
                 {
                   type: 'category',
                   label: 'Consensus',


### PR DESCRIPTION
# Description of change

Added the mana calculator to the sidebar. This needs to be merged before the release

## Type of change

- Documentation Enhancement

## Change checklist

- [x] I have followed the [contribution guidelines](https://github.com/iota-wiki/iota-wiki/blob/main/.github/CONTRIBUTING.md) for this project
- [x] I have performed a self-review of my own changes
- [x] I have made sure that added/changed links still work
- [ ] I have commented my code, particularly in hard-to-understand areas
