### PR TITLE
Mana Calculator - Sync values on owned amount changes

### DIFF
--- a/src/components/ManaCalculator/components/ValidatorSettings.tsx
+++ b/src/components/ManaCalculator/components/ValidatorSettings.tsx
@@ -52,7 +52,9 @@ export function ValidatorSettings() {
           0,
         )}
         onChange={(e) =>
-          handleAttractedNewDelegatedStakeChange(Number(e.target.value))
+          handleAttractedNewDelegatedStakeChange(
+            toMicro(Number(e.target.value)),
+          )
         }
       ></input>
     </Details>

--- a/src/components/ManaCalculator/hooks/useManaState.ts
+++ b/src/components/ManaCalculator/hooks/useManaState.ts
@@ -153,6 +153,15 @@ export function useGivenManaState(
     setState({
       ...state,
       userType: value,
+      [getStakedOrDelegated(value)]: state.heldTokens,
+      ...(value === UserType.VALIDATOR
+        ? {
+            validator: {
+              ...state.validator,
+              attractedNewDelegatedStake: state.heldTokens,
+            },
+          }
+        : {}),
     });
   }
 
@@ -162,7 +171,27 @@ export function useGivenManaState(
   }
 
   function handleOwnHoldChange(value: number) {
-    setState({ ...state, heldTokens: value });
+    setState({
+      ...state,
+      ...getDerivedValuesFromHeldTokens(value),
+    });
+  }
+
+  function getDerivedValuesFromHeldTokens(
+    heldTokens: number,
+  ): Partial<ManaCalculatorProps> {
+    return {
+      heldTokens,
+      [getStakedOrDelegated(state.userType)]: heldTokens,
+      ...(state.userType === UserType.VALIDATOR
+        ? {
+            validator: {
+              ...state.validator,
+              attractedNewDelegatedStake: heldTokens,
+            },
+          }
+        : {}),
+    };
   }
 
   const congestionAmount = getNetworkCongestion(


### PR DESCRIPTION
# Description of change

- Fix changing attracted new delegated stake setting to zero when pressing numbers
- Sync value from owned amount with Attracted new delegated stake and Staked amount

## Links to any relevant issues

Fixes #1353 

## Type of change

- Documentation Enhancement

## Change checklist

- [x] I have followed the [contribution guidelines](https://github.com/iota-wiki/iota-wiki/blob/main/.github/CONTRIBUTING.md) for this project
- [ ] I have performed a self-review of my own changes
- [ ] I have made sure that added/changed links still work
- [ ] I have commented my code, particularly in hard-to-understand areas
