### PR TITLE
Fix incorrect entry point

### DIFF
--- a/docs/build/wasp-evm/v1.0.0-rc.6/docs/reference/core-contracts/evm.md
+++ b/docs/build/wasp-evm/v1.0.0-rc.6/docs/reference/core-contracts/evm.md
@@ -88,7 +88,7 @@ A, and the owner of the foundry wishes to register the ERC20 contract on chain
 B. In that case, the owner must call this endpoint on chain A with `target =
 chain B`. The request to chain B is then sent as an on-ledger request.
 After a few minutes, call
-[`getERC20ExternalNativeTokensAddress`](#geterc20externalnativetokensaddress)
+[`getERC20ExternalNativeTokenAddress`](#geterc20externalnativetokenaddress)
 on chain B to find out the address of the ERC20 contract.
 
 #### Parameters
@@ -138,7 +138,7 @@ The call will fail if the address is taken by another collection with the same p
 
 ## Views
 
-### `getERC20ExternalNativeTokensAddress`
+### `getERC20ExternalNativeTokenAddress`
 
 Returns the address of an ERC20 contract registered with
 [`registerERC20NativeTokenOnRemoteChain`](#registererc20nativetokenonchain).


### PR DESCRIPTION
# Description of change

Updated evm contract entrypoint for `getERC20ExternalNativeTokenAddress` to correct singular form

## Type of change

- Documentation Fix

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [☑] I have followed the [contribution guidelines](https://github.com/iota-wiki/iota-wiki/blob/main/.github/CONTRIBUTING.md) for this project
- [☑] I have performed a self-review of my own changes
- [☑] I have made sure that added/changed links still work
- [☑] I have commented my code, particularly in hard-to-understand areas
