### PR TITLE
Renamed deprecated label IotaWallet.NET to IotaSDK.NET

### DIFF
--- a/docs/build/getting-started/sidebars.ts
+++ b/docs/build/getting-started/sidebars.ts
@@ -69,7 +69,7 @@ module.exports = {
         },
         {
           type: 'link',
-          label: 'IotaWallet.NET',
+          label: 'IotaSDK.NET',
           href: 'https://github.com/IOTA-NET/IotaSDK.NET',
         },
         {


### PR DESCRIPTION
# Description of change

Please write a summary of your changes and why you made them.

Renamed deprecated label IotaWallet.NET to IotaSDK.NET
## Type of change


- Documentation Fix

\
