### PR TITLE
Update sign-ed25519.mdx

### DIFF
--- a/docs/build/iota-sdk/1.0/docs/how-tos/sign-and-verify-ed25519/sign-ed25519.mdx
+++ b/docs/build/iota-sdk/1.0/docs/how-tos/sign-and-verify-ed25519/sign-ed25519.mdx
@@ -49,7 +49,7 @@ https://github.com/iotaledger/iota-sdk/blob/develop/sdk/examples/how_tos/sign_an
 <div className={'hide-code-block-extras'}>
 
 ```rust reference
-https://github.com/iotaledger/iota-sdk/blob/develop/sdk/examples/how_tos/sign_and_verify_ed25519/sign_ed25519.rs#L61
+https://github.com/iotaledger/iota-sdk/blob/develop/sdk/examples/how_tos/sign_and_verify_ed25519/sign_ed25519.rs#L61-L62
 ```
 
 </div>


### PR DESCRIPTION
# Description of change

Fixes the Rust part https://wiki.iota.org/iota-sdk/how-tos/sign-and-verify-ed25519/sign-ed25519/?language=rust because it currently only shows `let bech32_address =`

## Type of change

- Documentation Fix
