### PR TITLE
Sandbox - add credentials closer to their urls

### DIFF
--- a/docs/build/iota-sandbox/docs/references/endpoints.md
+++ b/docs/build/iota-sandbox/docs/references/endpoints.md
@@ -52,12 +52,6 @@ http://localhost/faucet/
 
 ## Wasp
 
-:::info Profile
-
-Wasp is not active by default. You need to enable the `wasp` profile to use it.
-
-:::
-
 ### Dashboard 
 
 ```plaintext

--- a/docs/build/iota-sandbox/docs/references/endpoints.md
+++ b/docs/build/iota-sandbox/docs/references/endpoints.md
@@ -3,6 +3,9 @@ title: Endpoints
 description: Endpoints of the IOTA Sandbox
 keywords:
   - api
+  - passwords
+  - users
+  - credentials
   - endpoints
   - reference
 ---
@@ -16,13 +19,36 @@ you can access the following endpoints:
 
 ## Hornet
 
-Dashboard: `http://localhost/`  
-API: `http://localhost/`
+### Dashboard 
+
+```plaintext
+http://localhost/
+```
+
+#### Default Credentials
+
+**Username**: `admin`  
+**Password**: `admin`
+
+### API
+
+```plaintext
+http://localhost/
+```
 
 ## Faucet
 
-Frontend: `http://localhost/faucet/`  
-API: `http://localhost/faucet/`
+### Frontend
+
+```plaintext
+http://localhost/faucet/
+```  
+
+### API
+
+```plaintext
+http://localhost/faucet/
+```
 
 ## Wasp
 
@@ -32,12 +58,30 @@ Wasp is not active by default. You need to enable the `wasp` profile to use it.
 
 :::
 
-Dashboard: `http://localhost/wasp/`  
-API: `http://localhost/wasp/api/`
+### Dashboard 
+
+```plaintext
+http://localhost/wasp/
+```
+
+#### Default Credentials
+
+**Username**: `wasp`  
+**Password**: `wasp`
+
+### API
+
+```plaintext
+http://localhost/wasp/api/
+```
 
 ## Chronicle
 
-API: `http://localhost/chronicle/`
+### API 
+
+```plaintext
+http://localhost/chronicle/
+```
 
 ## EVM Toolkit
 
@@ -52,8 +96,21 @@ The EVM Toolkit is available on port `8082` by default. You can change it in the
 
 :::
 
-Frontend: `http://localhost:8082/`
+### Frontend 
+
+```plaintext
+http://localhost:8082/
+```
 
 ## Grafana
 
-Frontend: `http://localhost/grafana/`
+### Frontend 
+
+```plaintext
+http://localhost/grafana/
+```
+
+#### Default Credentials
+
+**Username**: `admin`  
+**Password**: `admin`

--- a/docs/build/iota-sandbox/docs/references/endpoints.md
+++ b/docs/build/iota-sandbox/docs/references/endpoints.md
@@ -1,6 +1,6 @@
 ---
 title: Endpoints
-description: Endpoints of the IOTA Sandbox
+description: Endpoints and credentials of the IOTA Sandbox
 keywords:
   - api
   - passwords

--- a/docs/build/iota-sandbox/docs/references/keys.md
+++ b/docs/build/iota-sandbox/docs/references/keys.md
@@ -1,9 +1,8 @@
 ---
-title: Keys and Passwords for the IOTA Sandbox
-description: Keys and Passwords for the IOTA Sandbox
+title: Keys for the IOTA Sandbox
+description: Keys for the IOTA Sandbox
 keywords:
   - keys
-  - passwords
   - reference
 ---
 ## Keys 
@@ -34,21 +33,3 @@ You can use the following mnemonics and keys to access while working with the IO
 | Token ed25519 private key           | d50e772a711c3bf71ae676a8dc6a9726346c200d676a8fa7a6e254f341233115e073300fae90b10163e4b2b70c3fa8a93360992ed1a4cc2f6b386b5121c540a4                        |
 | Token bech32 address with `snd` HRP | snd1qqweu75ldpyann5jsthqsa6m0thx4tmqxncj6uqxf5q974pmqx30yfng7ya                                                                                         |
 
-## Passwords
-
-You can use the following credentials to access dashboards within the IOTA Sandbox.
-
-### Hornet Dashboard
-
-**Username**: `admin`  
-**Password**: `admin`
-
-### Wasp Dashboard
-
-**Username**: `wasp`  
-**Password**: `wasp`
-
-### Grafana Dashboard
-
-**Username**: `admin`  
-**Password**: `admin`


### PR DESCRIPTION
# Description of change

* moved credentials next to their URLs for easier access
* made URLs into a full code block to facilitate copy-pasting them

## Type of change


- Documentation Enhancement

## Change checklist

- [x] I have followed the [contribution guidelines](https://github.com/iota-wiki/iota-wiki/blob/main/.github/CONTRIBUTING.md) for this project
- [x] I have performed a self-review of my own changes
- [x] I have made sure that added/changed links still work
- [x] I have commented my code, particularly in hard-to-understand areas
