### PR TITLE
Add alias id and address of ISC chains

### DIFF
--- a/docs/build/getting-started/networks-endpoints.mdx
+++ b/docs/build/getting-started/networks-endpoints.mdx
@@ -63,7 +63,7 @@ Mainnet.
 
 | Chain Address | Alias ID |
 |--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------------------------------------|
-|[smr1prxvwqvwf7nru5q5xvh5thwg54zsm2y4wfnk6yk56hj3exxkg92mx20wl3s](https://explorer.shimmer.network/addr/smr1prxvwqvwf7nru5q5xvh5thwg54zsm2y4wfnk6yk56hj3exxkg92mx20wl3s)|0xccc7018e4fa63e5014332f45ddc8a5450da89572676d12d4d5e51c98d64155b3|
+|[smr1prxvwqvwf7nru5q5xvh5thwg54zsm2y4wfnk6yk56hj3exxkg92mx20wl3s](https://explorer.shimmer.network/shimmer/addr/smr1prxvwqvwf7nru5q5xvh5thwg54zsm2y4wfnk6yk56hj3exxkg92mx20wl3s)|0xccc7018e4fa63e5014332f45ddc8a5450da89572676d12d4d5e51c98d64155b3|
 
 ## Public Testnet
 

--- a/docs/build/getting-started/networks-endpoints.mdx
+++ b/docs/build/getting-started/networks-endpoints.mdx
@@ -59,6 +59,12 @@ Mainnet.
 | ------------- | --------- | -------- | ----------------------------------------------------------------------------- | ------------------------------------ |
 | Shimmer Token | ISC / EVM | <ChainId url='https://json-rpc.evm.shimmer.network'/>      | https://json-rpc.evm.shimmer.network or wss://ws.json-rpc.evm.shimmer.network | https://explorer.evm.shimmer.network |
 
+#### Additional Info
+
+| Chain Address | Alias ID |
+|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------------------------------------|
+|[smr1prxvwqvwf7nru5q5xvh5thwg54zsm2y4wfnk6yk56hj3exxkg92mx20wl3s](https://explorer.shimmer.network/addr/smr1prxvwqvwf7nru5q5xvh5thwg54zsm2y4wfnk6yk56hj3exxkg92mx20wl3s)|0xccc7018e4fa63e5014332f45ddc8a5450da89572676d12d4d5e51c98d64155b3|
+
 ## Public Testnet
 
 [The Public Testnet](https://explorer.iota.org/testnet) acts as a test bed for builders without any real world value.
@@ -81,9 +87,17 @@ any IOTA protocol but instead uses ISC to facilitate an Ethereum Virtual Machine
 layer 1.
 
 :::info
+
 This network is subject to occasional resets (no data retention) which are usually announced with a one-week grace period.
+
 :::
 
 | Base Token                | Protocol  | Chain ID | RPC URL                                      | Faucet                                     | Explorer                                     |
 | ------------------------- | --------- | -------- | -------------------------------------------- | ------------------------------------------ | -------------------------------------------- |
 | Testnet Tokens (no value) | ISC / EVM | <ChainId url='https://json-rpc.evm.testnet.shimmer.network'/> | https://json-rpc.evm.testnet.shimmer.network | https://evm-faucet.testnet.shimmer.network | https://explorer.evm.testnet.shimmer.network |
+
+#### Additional Info
+
+| Chain Address | Alias ID |
+|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------------------------------------|
+|[rms1ppp00k5mmd2m8my8ukkp58nd3rskw6rx8l09aj35984k74uuc5u2cywn3ex](https://explorer.shimmer.network/testnet/addr/rms1ppp00k5mmd2m8my8ukkp58nd3rskw6rx8l09aj35984k74uuc5u2cywn3ex)|0x42f7da9bdb55b3ec87e5ac1a1e6d88e16768663fde5eca3429eb6f579cc538ac|


### PR DESCRIPTION
# Description of change

I added the alias ID and chain address for both our EVMs which might be needed for depositing and/or cross chain references

## Type of change

- Documentation Enhancement

## Change checklist

- [x] I have followed the [contribution guidelines](https://github.com/iota-wiki/iota-wiki/blob/main/.github/CONTRIBUTING.md) for this project
- [x] I have performed a self-review of my own changes
- [x] I have made sure that added/changed links still work