### PR TITLE
Enable npm2yarn plugin

### DIFF
--- a/src/common/defaultContentPlugin.js
+++ b/src/common/defaultContentPlugin.js
@@ -11,6 +11,7 @@ module.exports = async () => {
       require('remark-code-import'),
       require('remark-import-partial'),
       require('remark-remove-comments'),
+      [require('@docusaurus/remark-plugin-npm2yarn'), { sync: true }],
     ],
     rehypePlugins: [
       require('rehype-katex'),


### PR DESCRIPTION
# Description of change

This enables the npm2yarn plugin to automatically create tabs for npm, Yarn and pnpm where npm is used in a codeblock.

## Links to any relevant issues

Fixes #1486 

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the [contribution guidelines](https://github.com/iota-wiki/iota-wiki/blob/main/.github/CONTRIBUTING.md) for this project
- [x] I have performed a self-review of my own changes
- [x] I have made sure that added/changed links still work
- [x] I have commented my code, particularly in hard-to-understand areas
