### PR TITLE
Let the link checker only open an new issues when all previous issues are closed

### DIFF
--- a/.github/workflows/broken-links-check.yaml
+++ b/.github/workflows/broken-links-check.yaml
@@ -27,14 +27,38 @@ jobs:
         if: always() && steps.check-links.outcome == 'failure'
         with:
           script: |
+            const title: 'Fix broken links';
+            const previousIssues = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              creator: context.actor,
+            });
+            for (const issue in previousIssues) {
+              if (issue.title !== title) continue;
+
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                body: 'Closing because of new report available.'
+              });
+
+              await octokit.rest.issues.update({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                state: "closed",
+              });
+            }
             const fs = require('fs');
             const input = fs.readFileSync('stderr.txt');
             const data = JSON.parse(input);
             const urls = data.map(item => item.url);
             const output = urls.map(url => `- [ ] ${url}`).join('\n');
-            github.rest.issues.create({
+            await github.rest.issues.create({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              title: 'Fix broken links',
+              title,
               body: `The following links are possibly broken:\n${output}`,
             });

--- a/.github/workflows/broken-links-check.yaml
+++ b/.github/workflows/broken-links-check.yaml
@@ -28,37 +28,28 @@ jobs:
         with:
           script: |
             const title: 'Fix broken links';
+
             const previousIssues = await github.rest.issues.listForRepo({
               owner: context.repo.owner,
               repo: context.repo.repo,
               state: 'open',
               creator: context.actor,
             });
-            for (const issue in previousIssues) {
-              if (issue.title !== title) continue;
 
-              await github.rest.issues.createComment({
+            const previousIssueExists = previousIssues.some((issue) => {
+              issue.title === title;
+            })
+
+            if !previousIssueExists {
+              const fs = require('fs');
+              const input = fs.readFileSync('stderr.txt');
+              const data = JSON.parse(input);
+              const urls = data.map(item => item.url);
+              const output = urls.map(url => `- [ ] ${url}`).join('\n');
+              await github.rest.issues.create({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
-                issue_number: issue.number,
-                body: 'Closing because of new report available.'
-              });
-
-              await octokit.rest.issues.update({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: issue.number,
-                state: "closed",
+                title,
+                body: `The following links are possibly broken:\n${output}`,
               });
             }
-            const fs = require('fs');
-            const input = fs.readFileSync('stderr.txt');
-            const data = JSON.parse(input);
-            const urls = data.map(item => item.url);
-            const output = urls.map(url => `- [ ] ${url}`).join('\n');
-            await github.rest.issues.create({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              title,
-              body: `The following links are possibly broken:\n${output}`,
-            });


### PR DESCRIPTION
# Description of change

This is an attempt to let the link checker only open a new issue when all previous issues have been closed.

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the [contribution guidelines](https://github.com/iota-wiki/iota-wiki/blob/main/.github/CONTRIBUTING.md) for this project
- [x] I have performed a self-review of my own changes
- [x] I have made sure that added/changed links still work
- [x] I have commented my code, particularly in hard-to-understand areas
