### PR TITLE
ISC remove Truffle mention as it is being sunset

### DIFF
--- a/docs/build/isc/v1.0.0-rc.6/docs/getting-started/quick-start.mdx
+++ b/docs/build/isc/v1.0.0-rc.6/docs/getting-started/quick-start.mdx
@@ -58,7 +58,7 @@ If you want to fund your ShimmerEVM account, please refer to our [How To Get Fun
 
 ## Deploy and Interact with Smart Contracts
 
-You can now use your testnet SMR tokens and simulated bridged tokens to deploy and interact with smart contracts on the [Public Testnet](/build/networks-endpoints/#public-testnet). Utilize popular development tools and frameworks, such as [Truffle](https://www.trufflesuite.com/), [Hardhat](https://hardhat.org/), or [Remix](https://remix.ethereum.org/), to build, test, and deploy your smart contracts.
+You can now use your testnet SMR tokens and simulated bridged tokens to deploy and interact with smart contracts on the [Public Testnet](/build/networks-endpoints/#public-testnet). Utilize popular development tools and frameworks, such as [Hardhat](https://hardhat.org/), or [Remix](https://remix.ethereum.org/), to build, test, and deploy your smart contracts.
 
 ## Explore the Public Testnet
 


### PR DESCRIPTION
# Description of change

Removed Truffle as it is being sunset as stated [in this announcement](https://consensys.io/blog/consensys-announces-the-sunset-of-truffle-and-ganache-and-new-hardhat?utm_source=github&utm_medium=referral&utm_campaign=2023_Sep_truffle-sunset-2023_announcement_)

## Type of change

- Documentation Fix

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the [contribution guidelines](https://github.com/iota-wiki/iota-wiki/blob/main/.github/CONTRIBUTING.md) for this project
- [x] I have performed a self-review of my own changes
- [x] I have made sure that added/changed links still work
- [x] I have commented my code, particularly in hard-to-understand areas
