### PR TITLE
Fix tip links pointing to merged version branches

### DIFF
--- a/docs/build/identity.rs/1.0/docs/references/specifications/iota-did-method-spec.mdx
+++ b/docs/build/identity.rs/1.0/docs/references/specifications/iota-did-method-spec.mdx
@@ -22,7 +22,7 @@ The IOTA DID Method Specification describes a method of implementing the [Decent
 
 ## Data Types & Subschema Notation
 
-Data types and subschemas used throughout this TIP are defined in [TIP-21](https://github.com/iotaledger/tips/blob/v1.0.0/tips/TIP-0021/tip-0021.md).
+Data types and subschemas used throughout this TIP are defined in [TIP-21](https://github.com/iotaledger/tips/blob/main/tips/TIP-0021/tip-0021.md).
 
 ## Introduction
 
@@ -36,13 +36,13 @@ Data stored in an output and covered by the storage deposit will be stored in _a
 
 ### Alias Output
 
-The [Alias Output](https://github.com/iotaledger/tips/blob/v1.0.0/tips/TIP-0018/tip-0018.md#alias-output) is a specific implementation of the [UTXO state machine](https://github.com/iotaledger/tips/blob/v1.0.0/tips/TIP-0018/tip-0018.md#chain-constraint-in-utxo). Some of its relevant properties are:
+The [Alias Output](https://github.com/iotaledger/tips/blob/main/tips/TIP-0018/tip-0018.md#alias-output) is a specific implementation of the [UTXO state machine](https://github.com/iotaledger/tips/blob/main/tips/TIP-0018/tip-0018.md#chain-constraint-in-utxo). Some of its relevant properties are:
 
 - **Amount**: the amount of IOTA coins held by the output.
 - **Alias ID**: 32 byte array, a unique identifier of the alias, which is the BLAKE2b-256 hash
   of the Output ID that created it.
 - **State Index**: A counter that must increase by 1 every time the alias is state transitioned.
-- **State Metadata**: Dynamically sized array of arbitrary bytes with a length up to `Max Metadata Length`, as defined in [TIP-22](https://github.com/iotaledger/tips/blob/v1.0.0/tips/TIP-0022/tip-0022.md). Can only be changed by the state controller.
+- **State Metadata**: Dynamically sized array of arbitrary bytes with a length up to `Max Metadata Length`, as defined in [TIP-22](https://github.com/iotaledger/tips/blob/main/tips/TIP-0022/tip-0022.md). Can only be changed by the state controller.
 - **Unlock Conditions**:
   - State Controller Address Unlock Condition
   - Governor Address Unlock Condition

--- a/docs/build/identity.rs/1.0/docs/references/specifications/revocation-bitmap-2022.mdx
+++ b/docs/build/identity.rs/1.0/docs/references/specifications/revocation-bitmap-2022.mdx
@@ -175,7 +175,7 @@ This section describes the rationale behind some of the design decisions of this
 
 ### Compression and maximum size
 
-Considering that messages published to the Tangle cannot exceed [32 KiB](https://github.com/iotaledger/tips/blob/v1.0.0/tips/TIP-0006/tip-0006.md#message-validation) in size, and that larger messages have increased requirements, the use of compression was assessed.
+Considering that messages published to the Tangle cannot exceed [32 KiB](https://github.com/iotaledger/tips/blob/main/tips/TIP-0006/tip-0006.md#message-validation) in size, and that larger messages have increased requirements, the use of compression was assessed.
 The precise size of a serialized bitmap varies based on the number and distribution of revoked indices. When indices are revoked uniformly randomly, roughly 100,000 - 200,000 can be achieved in a DID Document with compression, and significantly more if consecutive indices are revoked.
 
 ZLIB [[RFC 1950](https://datatracker.ietf.org/doc/html/rfc1950)] was chosen for having a free and open source software licence and being one of the most widely used compression schemes, which enhances the accessibility of this specification. Some other assessed algorithms produced only marginally better compression ratios but had far fewer existing implementations across different programming languages.

--- a/docs/build/identity.rs/1.1/docs/references/specifications/iota-did-method-spec.mdx
+++ b/docs/build/identity.rs/1.1/docs/references/specifications/iota-did-method-spec.mdx
@@ -22,7 +22,7 @@ The IOTA DID Method Specification describes a method of implementing the [Decent
 
 ## Data Types & Subschema Notation
 
-Data types and subschemas used throughout this TIP are defined in [TIP-21](https://github.com/iotaledger/tips/blob/v1.1.0/tips/TIP-0021/tip-0021.md).
+Data types and subschemas used throughout this TIP are defined in [TIP-21](https://github.com/iotaledger/tips/blob/main/tips/TIP-0021/tip-0021.md).
 
 ## Introduction
 
@@ -36,13 +36,13 @@ Data stored in an output and covered by the storage deposit will be stored in _a
 
 ### Alias Output
 
-The [Alias Output](https://github.com/iotaledger/tips/blob/v1.1.0/tips/TIP-0018/tip-0018.md#alias-output) is a specific implementation of the [UTXO state machine](https://github.com/iotaledger/tips/blob/v1.1.0/tips/TIP-0018/tip-0018.md#chain-constraint-in-utxo). Some of its relevant properties are:
+The [Alias Output](https://github.com/iotaledger/tips/blob/main/tips/TIP-0018/tip-0018.md#alias-output) is a specific implementation of the [UTXO state machine](https://github.com/iotaledger/tips/blob/main/tips/TIP-0018/tip-0018.md#chain-constraint-in-utxo). Some of its relevant properties are:
 
 - **Amount**: the amount of IOTA coins held by the output.
 - **Alias ID**: 32 byte array, a unique identifier of the alias, which is the BLAKE2b-256 hash
   of the Output ID that created it.
 - **State Index**: A counter that must increase by 1 every time the alias is state transitioned.
-- **State Metadata**: Dynamically sized array of arbitrary bytes with a length up to `Max Metadata Length`, as defined in [TIP-22](https://github.com/iotaledger/tips/blob/v1.1.0/tips/TIP-0022/tip-0022.md). Can only be changed by the state controller.
+- **State Metadata**: Dynamically sized array of arbitrary bytes with a length up to `Max Metadata Length`, as defined in [TIP-22](https://github.com/iotaledger/tips/blob/main/tips/TIP-0022/tip-0022.md). Can only be changed by the state controller.
 - **Unlock Conditions**:
   - State Controller Address Unlock Condition
   - Governor Address Unlock Condition

--- a/docs/build/identity.rs/1.1/docs/references/specifications/revocation-bitmap-2022.mdx
+++ b/docs/build/identity.rs/1.1/docs/references/specifications/revocation-bitmap-2022.mdx
@@ -175,7 +175,7 @@ This section describes the rationale behind some of the design decisions of this
 
 ### Compression and maximum size
 
-Considering that messages published to the Tangle cannot exceed [32 KiB](https://github.com/iotaledger/tips/blob/v1.1.0/tips/TIP-0006/tip-0006.md#message-validation) in size, and that larger messages have increased requirements, the use of compression was assessed.
+Considering that messages published to the Tangle cannot exceed [32 KiB](https://github.com/iotaledger/tips/blob/main/tips/TIP-0006/tip-0006.md#message-validation) in size, and that larger messages have increased requirements, the use of compression was assessed.
 The precise size of a serialized bitmap varies based on the number and distribution of revoked indices. When indices are revoked uniformly randomly, roughly 100,000 - 200,000 can be achieved in a DID Document with compression, and significantly more if consecutive indices are revoked.
 
 ZLIB [[RFC 1950](https://datatracker.ietf.org/doc/html/rfc1950)] was chosen for having a free and open source software licence and being one of the most widely used compression schemes, which enhances the accessibility of this specification. Some other assessed algorithms produced only marginally better compression ratios but had far fewer existing implementations across different programming languages.

--- a/docs/build/identity.rs/1.2/docs/references/specifications/iota-did-method-spec.mdx
+++ b/docs/build/identity.rs/1.2/docs/references/specifications/iota-did-method-spec.mdx
@@ -22,7 +22,7 @@ The IOTA DID Method Specification describes a method of implementing the [Decent
 
 ## Data Types & Subschema Notation
 
-Data types and subschemas used throughout this TIP are defined in [TIP-21](https://github.com/iotaledger/tips/blob/v1.2.0/tips/TIP-0021/tip-0021.md).
+Data types and subschemas used throughout this TIP are defined in [TIP-21](https://github.com/iotaledger/tips/blob/main/tips/TIP-0021/tip-0021.md).
 
 ## Introduction
 
@@ -36,13 +36,13 @@ Data stored in an output and covered by the storage deposit will be stored in _a
 
 ### Alias Output
 
-The [Alias Output](https://github.com/iotaledger/tips/blob/v1.2.0/tips/TIP-0018/tip-0018.md#alias-output) is a specific implementation of the [UTXO state machine](https://github.com/iotaledger/tips/blob/v1.2.0/tips/TIP-0018/tip-0018.md#chain-constraint-in-utxo). Some of its relevant properties are:
+The [Alias Output](https://github.com/iotaledger/tips/blob/main/tips/TIP-0018/tip-0018.md#alias-output) is a specific implementation of the [UTXO state machine](https://github.com/iotaledger/tips/blob/main/tips/TIP-0018/tip-0018.md#chain-constraint-in-utxo). Some of its relevant properties are:
 
 - **Amount**: the amount of IOTA coins held by the output.
 - **Alias ID**: 32 byte array, a unique identifier of the alias, which is the BLAKE2b-256 hash
   of the Output ID that created it.
 - **State Index**: A counter that must increase by 1 every time the alias is state transitioned.
-- **State Metadata**: Dynamically sized array of arbitrary bytes with a length up to `Max Metadata Length`, as defined in [TIP-22](https://github.com/iotaledger/tips/blob/v1.2.0/tips/TIP-0022/tip-0022.md). Can only be changed by the state controller.
+- **State Metadata**: Dynamically sized array of arbitrary bytes with a length up to `Max Metadata Length`, as defined in [TIP-22](https://github.com/iotaledger/tips/blob/main/tips/TIP-0022/tip-0022.md). Can only be changed by the state controller.
 - **Unlock Conditions**:
   - State Controller Address Unlock Condition
   - Governor Address Unlock Condition

--- a/docs/build/identity.rs/1.2/docs/references/specifications/revocation-bitmap-2022.mdx
+++ b/docs/build/identity.rs/1.2/docs/references/specifications/revocation-bitmap-2022.mdx
@@ -175,7 +175,7 @@ This section describes the rationale behind some of the design decisions of this
 
 ### Compression and maximum size
 
-Considering that messages published to the Tangle cannot exceed [32 KiB](https://github.com/iotaledger/tips/blob/v1.2.0/tips/TIP-0006/tip-0006.md#message-validation) in size, and that larger messages have increased requirements, the use of compression was assessed.
+Considering that messages published to the Tangle cannot exceed [32 KiB](https://github.com/iotaledger/tips/blob/main/tips/TIP-0006/tip-0006.md#message-validation) in size, and that larger messages have increased requirements, the use of compression was assessed.
 The precise size of a serialized bitmap varies based on the number and distribution of revoked indices. When indices are revoked uniformly randomly, roughly 100,000 - 200,000 can be achieved in a DID Document with compression, and significantly more if consecutive indices are revoked.
 
 ZLIB [[RFC 1950](https://datatracker.ietf.org/doc/html/rfc1950)] was chosen for having a free and open source software licence and being one of the most widely used compression schemes, which enhances the accessibility of this specification. Some other assessed algorithms produced only marginally better compression ratios but had far fewer existing implementations across different programming languages.


### PR DESCRIPTION
# Description of change

Found some TIP links that were pointing to a version branch that had been merged.

This PR updates those links to use main branch.

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Documentation Fix

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the [contribution guidelines](https://github.com/iota-wiki/iota-wiki/blob/main/.github/CONTRIBUTING.md) for this project
- [x] I have performed a self-review of my own changes
- [x] I have made sure that added/changed links still work
