### PR TITLE
Update using_docker.md

### DIFF
--- a/docs/maintain/hornet/2.0/docs/how_tos/using_docker.md
+++ b/docs/maintain/hornet/2.0/docs/how_tos/using_docker.md
@@ -75,7 +75,7 @@ mkdir node-docker-setup && cd node-docker-setup && curl -L https://node-docker-s
 <TabItem value="testnet" label="Testnet">
 
 ```sh
-mkdir node-docker-setup && cd node-docker-setup && curl -L https://node-docker-setup.iota.org/testnet | tar -zx
+mkdir node-docker-setup && cd node-docker-setup && curl -L https://node-docker-setup.iota.org/iota2-testnet | tar -zx
 ```
 
 </TabItem>


### PR DESCRIPTION
# Description of change

link for downloading the iota2-testnet files were wrong. Old link just gives an "forbidden" error msg.

## Links to any relevant issues

Be sure to reference any related issues by adding `fixes #issue_number`.

## Type of change

- Documentation Fix

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [x ] I have followed the [contribution guidelines](https://github.com/iota-wiki/iota-wiki/blob/main/.github/CONTRIBUTING.md) for this project
- [x ] I have performed a self-review of my own changes
- [x ] I have made sure that added/changed links still work
