### PR TITLE
Fix "create native token" how-to

### DIFF
--- a/docs/build/isc/v1.0.0-rc.6/docs/how-tos/core-contracts/token/create-native-token.md
+++ b/docs/build/isc/v1.0.0-rc.6/docs/how-tos/core-contracts/token/create-native-token.md
@@ -27,11 +27,11 @@ The Foundry lets you specify your native token's maximum supply **once** and cha
 
 ### 2. Define the Token Scheme
 
-Define the `NativeTokenScheme` by specifying its `mintedTokens`, `meltedTokens`, and `maximumSupply`. For simplicity, in this guide we mint the whole maximum supply at creation.
+Define the `NativeTokenScheme` by specifying the `maximumSupply`.
 
 ```solidity
 NativeTokenScheme memory nativeTokenScheme = NativeTokenScheme({
-    mintedTokens: _maximumSupply,
+    mintedTokens: 0,
     meltedTokens: 0,
     maximumSupply: _maximumSupply
 });
@@ -73,7 +73,7 @@ contract MyToken {
           allowance.baseTokens = _storageDeposit;
 
           NativeTokenScheme memory nativeTokenScheme = NativeTokenScheme({
-              mintedTokens: _maximumSupply,
+              mintedTokens: 0,
               meltedTokens: 0,
               maximumSupply: _maximumSupply
           });

--- a/docs/build/isc/v1.0.0-rc.6/docs/how-tos/core-contracts/token/mint-token.md
+++ b/docs/build/isc/v1.0.0-rc.6/docs/how-tos/core-contracts/token/mint-token.md
@@ -9,15 +9,10 @@ tags:
   - mint
 ---
 import ExampleCodeIntro from '../../../_partials/how-tos/token/_example_code_intro.md';
-import ObsoleteTokenCreation from '../../../_partials/how-tos/token/_obsolete_token_creation.md';
 
 # Mint a Native Token using a Foundry
 
-<ObsoleteTokenCreation/>
-
-
-To mint tokens from a [foundry](/tips/tips/TIP-0018/#foundry-output), you first need to be aware that only the foundry owner can mint token,
-so you should execute the `ISC.accounts.mintNativeTokens` function in the same contract that [created the foundry](./create-foundry.md).
+To mint tokens from a [foundry](/tips/tips/TIP-0018/#foundry-output), you first need to be aware that only the foundry owner can mint token, so you should execute the `ISC.accounts.mintNativeTokens` function in the same contract where you also [created the native token](./create-native-token.md).
 
 ## Example Code
 

--- a/docs/build/isc/v1.0.0-rc.6/docs/how-tos/core-contracts/token/mint-token.md
+++ b/docs/build/isc/v1.0.0-rc.6/docs/how-tos/core-contracts/token/mint-token.md
@@ -10,7 +10,7 @@ tags:
 ---
 import ExampleCodeIntro from '../../../_partials/how-tos/token/_example_code_intro.md';
 
-# Mint a Native Token using a Foundry
+# Mint Native Tokens
 
 To mint tokens from a [foundry](/tips/tips/TIP-0018/#foundry-output), you first need to be aware that only the foundry owner can mint token, so you should execute the `ISC.accounts.mintNativeTokens` function in the same contract where you also [created the native token](./create-native-token.md).
 

--- a/docs/build/isc/v1.0.0-rc.6/sidebars.js
+++ b/docs/build/isc/v1.0.0-rc.6/sidebars.js
@@ -156,6 +156,11 @@ module.exports = {
                 },
                 {
                   type: 'doc',
+                  label: 'Mint Native Tokens',
+                  id: 'how-tos/core-contracts/token/mint-token',
+                },
+                {
+                  type: 'doc',
                   label: 'Custom ERC20 Functions',
                   id: 'how-tos/core-contracts/token/erc20-native-token',
                 },
@@ -163,11 +168,6 @@ module.exports = {
                   type: 'doc',
                   label: 'Create a Foundry',
                   id: 'how-tos/core-contracts/token/create-foundry',
-                },
-                {
-                  type: 'doc',
-                  label: 'Mint a Native Token using a Foundry',
-                  id: 'how-tos/core-contracts/token/mint-token',
                 },
                 {
                   type: 'doc',


### PR DESCRIPTION
# Description of change

Removed the obsolete partial from Minting token, as you can still create the foundry without circulating supply and mint tokens later.
Also updated the how to as currently minting tokens in one step [still doesn't work](https://github.com/iotaledger/wasp/issues/3267). Your foundry will always have zero minted token.

## Type of change

- Documentation Fix

## Change checklist

- [x] I have followed the [contribution guidelines](https://github.com/iota-wiki/iota-wiki/blob/main/.github/CONTRIBUTING.md) for this project
- [x] I have performed a self-review of my own changes
- [x] I have made sure that added/changed links still work
- [x] I have commented my code, particularly in hard-to-understand areas
