### PR TITLE
Fix versionedConfig.js for Identity

### DIFF
--- a/config/versionedConfig.js
+++ b/config/versionedConfig.js
@@ -46,6 +46,10 @@ exports.buildPluginsConfig = [
     subsection: 'build-layer-1',
     versions: [
       {
+        label: '1.3',
+        badges: ['IOTA', 'Shimmer'],
+      },
+      {
         label: '1.2',
         badges: ['IOTA', 'Shimmer'],
       },


### PR DESCRIPTION
# Description of change

Seems like I fucked up the latest [PR](https://github.com/iotaledger/iota-wiki/pull/1552) where we moved the configs and undid the Identity change. This PR reverts that change.

## Type of change

- Documentation Fix

## Change checklist

- [x] I have followed the [contribution guidelines](https://github.com/iota-wiki/iota-wiki/blob/main/.github/CONTRIBUTING.md) for this project
- [x] I have performed a self-review of my own changes
- [x] I have made sure that added/changed links still work
- [x] I have commented my code, particularly in hard-to-understand areas
