### PR TITLE
Make EVM quick-start guide agnostic

### DIFF
--- a/docs/build/isc/v1.1/docs/getting-started/quick-start.mdx
+++ b/docs/build/isc/v1.1/docs/getting-started/quick-start.mdx
@@ -19,9 +19,9 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import Link from '@docusaurus/Link';
 
-# EVM Testnets Quickstart Guide
+# EVM Quickstart Guide
 
-This guide will help you quickly get started with our [EVM Testnets](/build/networks-endpoints), where you can deploy and interact with EVM-compatible smart contracts.
+This guide will help you quickly get started with our EVM Testnets, where you can deploy and interact with EVM-compatible smart contracts.
 
 ## Prerequisites
 
@@ -39,32 +39,36 @@ Please read [the MetaMask  section in the tools guide](tools.mdx#metamask) for a
 
 :::
 
-## Get Testnet Tokens
+## Deploy and Interact with Smart Contracts
 
 :::tip Fund your testnet account
 
-If you want to fund your EVM testnet account, please refer to our [How To Get Funds guide](../how-tos/send-funds-from-L1-to-L2.mdx).
-
-:::
+If you are using one of the testnets you can just use the the toolkit to get testnet tokens.
 
 1. Go to the [IOTA EVM](https://evm-toolkit.evm.testnet.iotaledger.net) or [ShimmerEVM](https://evm-toolkit.evm.testnet.shimmer.network/) Testnet Toolkit.
 2. Connect your MetaMask wallet by clicking "Connect Wallet" or paste an EVM address.
 3. Select the account you want to receive testnet tokens.
 4. Click "Send funds" to get testnet tokens.
 
-## Deploy and Interact with Smart Contracts
+:::
 
-You can now use your testnet tokens and simulated bridged tokens to deploy and interact with smart contracts on the testnets. Utilize popular development tools and frameworks, such as [Hardhat](https://hardhat.org/), or [Remix](https://remix.ethereum.org/), to build, test, and deploy your smart contracts.
+You can now deploy and interact with smart contracts. Utilize popular development tools and frameworks, such as [Hardhat](https://hardhat.org/), or [Remix](https://remix.ethereum.org/), to build, test, and deploy your smart contracts.
 
 <DeployAdmonition />
 
-## Explore the Public Testnet
+## Explore the Network
 
-Visit the corresponding Testnet Block Explorer to monitor the chain, track transactions, and explore deployed smart contracts.
+Visit the corresponding Block Explorer to monitor the chain, track transactions, and explore deployed smart contracts.
 
 <Tabs groupId='network' queryString>
+<TabItem value='iota' label='IOTA EVM'>
+<Link to={Networks['iota'].evm.blockExplorerUrls[0]}>Explorer</Link>
+</TabItem>
 <TabItem value='iota_testnet' label='IOTA EVM Testnet'>
 <Link to={Networks['iota_testnet'].evm.blockExplorerUrls[0]}>Explorer</Link>
+</TabItem>
+<TabItem value='shimmer' label='ShimmerEVM'>
+<Link to={Networks['shimmer'].evm.blockExplorerUrls[0]}>Explorer</Link>
 </TabItem>
 <TabItem value='shimmer_testnet' label='ShimmerEVM Testnet'>
 <Link to={Networks['shimmer_testnet'].evm.blockExplorerUrls[0]}>Explorer</Link>

--- a/docs/build/isc/v1.3-alpha/docs/getting-started/quick-start.mdx
+++ b/docs/build/isc/v1.3-alpha/docs/getting-started/quick-start.mdx
@@ -19,9 +19,9 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import Link from '@docusaurus/Link';
 
-# EVM Testnets Quickstart Guide
+# EVM Quickstart Guide
 
-This guide will help you quickly get started with our [EVM Testnets](/build/networks-endpoints), where you can deploy and interact with EVM-compatible smart contracts.
+This guide will help you quickly get started with our EVM Testnets, where you can deploy and interact with EVM-compatible smart contracts.
 
 ## Prerequisites
 
@@ -39,32 +39,36 @@ Please read [the MetaMask  section in the tools guide](tools.mdx#metamask) for a
 
 :::
 
-## Get Testnet Tokens
+## Deploy and Interact with Smart Contracts
 
 :::tip Fund your testnet account
 
-If you want to fund your EVM testnet account, please refer to our [How To Get Funds guide](../how-tos/send-funds-from-L1-to-L2.mdx).
-
-:::
+If you are using one of the testnets you can just use the the toolkit to get testnet tokens.
 
 1. Go to the [IOTA EVM](https://evm-toolkit.evm.testnet.iotaledger.net) or [ShimmerEVM](https://evm-toolkit.evm.testnet.shimmer.network/) Testnet Toolkit.
 2. Connect your MetaMask wallet by clicking "Connect Wallet" or paste an EVM address.
 3. Select the account you want to receive testnet tokens.
 4. Click "Send funds" to get testnet tokens.
 
-## Deploy and Interact with Smart Contracts
+:::
 
-You can now use your testnet tokens and simulated bridged tokens to deploy and interact with smart contracts on the testnets. Utilize popular development tools and frameworks, such as [Hardhat](https://hardhat.org/), or [Remix](https://remix.ethereum.org/), to build, test, and deploy your smart contracts.
+You can now deploy and interact with smart contracts. Utilize popular development tools and frameworks, such as [Hardhat](https://hardhat.org/), or [Remix](https://remix.ethereum.org/), to build, test, and deploy your smart contracts.
 
 <DeployAdmonition />
 
-## Explore the Public Testnet
+## Explore the Network
 
-Visit the corresponding Testnet Block Explorer to monitor the chain, track transactions, and explore deployed smart contracts.
+Visit the corresponding Block Explorer to monitor the chain, track transactions, and explore deployed smart contracts.
 
 <Tabs groupId='network' queryString>
+<TabItem value='iota' label='IOTA EVM'>
+<Link to={Networks['iota'].evm.blockExplorerUrls[0]}>Explorer</Link>
+</TabItem>
 <TabItem value='iota_testnet' label='IOTA EVM Testnet'>
 <Link to={Networks['iota_testnet'].evm.blockExplorerUrls[0]}>Explorer</Link>
+</TabItem>
+<TabItem value='shimmer' label='ShimmerEVM'>
+<Link to={Networks['shimmer'].evm.blockExplorerUrls[0]}>Explorer</Link>
 </TabItem>
 <TabItem value='shimmer_testnet' label='ShimmerEVM Testnet'>
 <Link to={Networks['shimmer_testnet'].evm.blockExplorerUrls[0]}>Explorer</Link>


### PR DESCRIPTION
# Description of change

As our quick start guide doesn't just mention testnets I made it agnostic

## Type of change

- Documentation Enhancement

## Change checklist

- [x] I have followed the [contribution guidelines](https://github.com/iota-wiki/iota-wiki/blob/main/.github/CONTRIBUTING.md) for this project
- [x] I have performed a self-review of my own changes
- [x] I have made sure that added/changed links still work
- [x] I have commented my code, particularly in hard-to-understand areas
