### PR TITLE
docs(isc-wiki): add block time to the glossary

### DIFF
--- a/config/jargon.js
+++ b/config/jargon.js
@@ -1,6 +1,8 @@
 module.exports = {
   access:
     'The ability to write to the ledger by issuing blocks.  In other contexts, it means who has permission to a particular digital asset.',
+  blocktime:
+    'Block Time refers to the average amount of time it takes for a new block to be added to a blockchain. This metric is critical as it determines the network speed and efficiency in processing transactions and maintaining consensus.',
   accessibility:
     'The ease of use and availability of a system or technology for users.',
   'accessible Writing':
@@ -478,6 +480,4 @@ module.exports = {
     'Measure of approval of each block using the voting power of the validation blocks" issuer.',
   'writing to the ledger':
     'The act of creating blocks containing transactions.',
-  blocktime:
-  'Block Time refers to the average amount of time it takes for a new block to be added to a blockchain. This metric is critical as it determines the network speed and efficiency in processing transactions and maintaining consensus.',
 };

--- a/config/jargon.js
+++ b/config/jargon.js
@@ -1,8 +1,6 @@
 module.exports = {
   access:
     'The ability to write to the ledger by issuing blocks.  In other contexts, it means who has permission to a particular digital asset.',
-  blocktime:
-    'Block Time refers to the average amount of time it takes for a new block to be added to a blockchain. This metric is critical as it determines the network speed and efficiency in processing transactions and maintaining consensus.',
   accessibility:
     'The ease of use and availability of a system or technology for users.',
   'accessible Writing':
@@ -52,6 +50,8 @@ module.exports = {
     'The process of receiving blocks, either created locally by a node or received from a neighbor.',
   'block signature':
     'Digital signatures attached to blocks to ensure their authenticity.',
+  'block time':
+    'Block Time refers to the average amount of time it takes for a new block to be added to a blockchain. This metric is critical as it determines the network speed and efficiency in processing transactions and maintaining consensus.',
   'block wrapper':
     'The block wrapper is additional data around the typical blocks giving  important metadata, including the version, time, and block issuer. This  metadata allows nodes to follow the right version of the Tangle, to verify the timestamp of blocks, and to identify the creator of each  block.',
   'blockchain bottleneck':

--- a/config/jargon.js
+++ b/config/jargon.js
@@ -478,4 +478,6 @@ module.exports = {
     'Measure of approval of each block using the voting power of the validation blocks" issuer.',
   'writing to the ledger':
     'The act of creating blocks containing transactions.',
+  blocktime:
+  'Block Time refers to the average amount of time it takes for a new block to be added to a blockchain. This metric is critical as it determines the network speed and efficiency in processing transactions and maintaining consensus.',
 };

--- a/docs/build/isc/v1.1/docs/getting-started/compatibility.md
+++ b/docs/build/isc/v1.1/docs/getting-started/compatibility.md
@@ -33,7 +33,7 @@ Here are some of the most important properties and limitations of EVM support in
 
 ### No Enforced Block Time
 
-There is no guaranteed _block time_. A new EVM "block" will be created only when an ISC block is created, and ISC does
+There is no guaranteed _blocktime_. A new EVM "block" will be created only when an ISC block is created, and ISC does
 not enforce an average block time. This means that block times are variable; a new block will be created as soon as needed. 
 
 ### The Magic Contract

--- a/docs/build/isc/v1.1/docs/getting-started/compatibility.md
+++ b/docs/build/isc/v1.1/docs/getting-started/compatibility.md
@@ -33,8 +33,8 @@ Here are some of the most important properties and limitations of EVM support in
 
 ### No Enforced Block Time
 
-There is no guaranteed _blocktime_. A new EVM "block" will be created only when an ISC block is created, and ISC does
-not enforce an average block time. This means that block times are variable; a new block will be created as soon as needed. 
+There is no guaranteed _block time_. A new EVM "_block_" will be created only when an ISC block is created, and ISC does
+not enforce an average _block time_. This means that block times are variable; a new block will be created as soon as needed. 
 
 ### The Magic Contract
 

--- a/docs/build/isc/v1.3-alpha/docs/getting-started/compatibility.md
+++ b/docs/build/isc/v1.3-alpha/docs/getting-started/compatibility.md
@@ -33,7 +33,7 @@ Here are some of the most important properties and limitations of EVM support in
 
 ### No Enforced Block Time
 
-There is no guaranteed _block time_. A new EVM "block" will be created only when an ISC block is created, and ISC does
+There is no guaranteed _blocktime_. A new EVM "block" will be created only when an ISC block is created, and ISC does
 not enforce an average block time. This means that block times are variable; a new block will be created as soon as needed. 
 
 ### The Magic Contract

--- a/docs/build/isc/v1.3-alpha/docs/getting-started/compatibility.md
+++ b/docs/build/isc/v1.3-alpha/docs/getting-started/compatibility.md
@@ -33,8 +33,8 @@ Here are some of the most important properties and limitations of EVM support in
 
 ### No Enforced Block Time
 
-There is no guaranteed _blocktime_. A new EVM "block" will be created only when an ISC block is created, and ISC does
-not enforce an average block time. This means that block times are variable; a new block will be created as soon as needed. 
+There is no guaranteed _block time_. A new EVM "block" will be created only when an ISC block is created, and ISC does
+not enforce an average _block time_. This means that block times are variable; a new block will be created as soon as needed. 
 
 ### The Magic Contract
 

--- a/docs/build/isc/v1.3-alpha/docs/getting-started/compatibility.md
+++ b/docs/build/isc/v1.3-alpha/docs/getting-started/compatibility.md
@@ -33,7 +33,7 @@ Here are some of the most important properties and limitations of EVM support in
 
 ### No Enforced Block Time
 
-There is no guaranteed _block time_. A new EVM "block" will be created only when an ISC block is created, and ISC does
+There is no guaranteed _block time_. A new EVM "_block_" will be created only when an ISC block is created, and ISC does
 not enforce an average _block time_. This means that block times are variable; a new block will be created as soon as needed. 
 
 ### The Magic Contract


### PR DESCRIPTION
# Description of change

I added block time to the glossary for [page](https://wiki.iota.org/isc/getting-started/compatibility/). I also searched the wiki for pages where block time was used but found none for now. I will continue to check in the future.

## Links to any relevant issues

fixes #1574 

## Type of change

- Documentation Enhancement

## Change checklist

- [x] I have followed the [contribution guidelines](https://github.com/iota-wiki/iota-wiki/blob/main/.github/CONTRIBUTING.md) for this project
- [x] I have performed a self-review of my own changes
- [x] I have made sure that added/changed links still work