### PR TITLE
docs(isc-wiki): remove duplicates for EVM and ShimmerEVM Testnet

### DIFF
--- a/docs/build/isc/v1.1/docs/getting-started/networks-and-chains.mdx
+++ b/docs/build/isc/v1.1/docs/getting-started/networks-and-chains.mdx
@@ -47,31 +47,6 @@ The other values (network name and currency symbol) can be whatever value you li
 
 <NetworkInfo.EvmCustom {...Networks['iota']}/>
 
-## IOTA EVM Testnet
-
-<AddToMetaMaskButton {...Networks['iota_testnet']} />
-
-[The IOTA EVM Testnet](https://explorer.evm.testnet.iotaledger.net/) runs as a layer 2 on top
-of the [IOTA Testnet](/build/networks-endpoints#iota-testnet). This network uses ISC to facilitate
-
-:::info
-
-This network is subject to occasional resets (no data retention) which are usually announced with a one-week grace period.
-
-:::
-
-<NetworkInfo.Evm {...Networks['iota_testnet']} />
-
-:::note
-
-The other values (network name and currency symbol) can be whatever value you like.
-
-:::
-
-### Additional Info
-
-<NetworkInfo.EvmCustom {...Networks['iota_testnet']}/>
-
 ## ShimmerEVM Testnet
 
 <AddToMetaMaskButton {...Networks['shimmer_testnet']} />
@@ -109,32 +84,6 @@ The other values (network name and currency symbol) can be whatever value you li
 ### Additional Info
 
 <NetworkInfo.EvmCustom {...Networks['shimmer']}/>
-
-## ShimmerEVM Testnet
-
-<AddToMetaMaskButton {...Networks['shimmer_testnet']} />
-
-[The ShimmerEVM Testnet](https://explorer.evm.testnet.shimmer.network/) runs as a layer 2 on top
-of the [Shimmer Testnet](/build/networks-endpoints#shimmer-testnet). This network uses ISC to facilitate
-an Ethereum Virtual Machine and has an enshrined bridge to layer 1.
-
-:::info
-
-This network is subject to occasional resets (no data retention) which are usually announced with a one-week grace period.
-
-:::
-
-<NetworkInfo.Evm {...Networks['shimmer_testnet']} />
-
-:::note
-
-The other values (network name and currency symbol) can be whatever value you like.
-
-:::
-
-### Additional Info
-
-<NetworkInfo.EvmCustom {...Networks['shimmer_testnet']}/>
 
 ## Core Contracts
 

--- a/docs/build/isc/v1.3-alpha/docs/getting-started/networks-and-chains.mdx
+++ b/docs/build/isc/v1.3-alpha/docs/getting-started/networks-and-chains.mdx
@@ -47,31 +47,6 @@ The other values (network name and currency symbol) can be whatever value you li
 
 <NetworkInfo.EvmCustom {...Networks['iota']}/>
 
-## IOTA EVM Testnet
-
-<AddToMetaMaskButton {...Networks['iota_testnet']} />
-
-[The IOTA EVM Testnet](https://explorer.evm.testnet.iotaledger.net/) runs as a layer 2 on top
-of the [IOTA Testnet](/build/networks-endpoints#iota-testnet). This network uses ISC to facilitate
-
-:::info
-
-This network is subject to occasional resets (no data retention) which are usually announced with a one-week grace period.
-
-:::
-
-<NetworkInfo.Evm {...Networks['iota_testnet']} />
-
-:::note
-
-The other values (network name and currency symbol) can be whatever value you like.
-
-:::
-
-### Additional Info
-
-<NetworkInfo.EvmCustom {...Networks['iota_testnet']}/>
-
 ## ShimmerEVM Testnet
 
 <AddToMetaMaskButton {...Networks['shimmer_testnet']} />
@@ -109,32 +84,6 @@ The other values (network name and currency symbol) can be whatever value you li
 ### Additional Info
 
 <NetworkInfo.EvmCustom {...Networks['shimmer']}/>
-
-## ShimmerEVM Testnet
-
-<AddToMetaMaskButton {...Networks['shimmer_testnet']} />
-
-[The ShimmerEVM Testnet](https://explorer.evm.testnet.shimmer.network/) runs as a layer 2 on top
-of the [Shimmer Testnet](/build/networks-endpoints#shimmer-testnet). This network uses ISC to facilitate
-an Ethereum Virtual Machine and has an enshrined bridge to layer 1.
-
-:::info
-
-This network is subject to occasional resets (no data retention) which are usually announced with a one-week grace period.
-
-:::
-
-<NetworkInfo.Evm {...Networks['shimmer_testnet']} />
-
-:::note
-
-The other values (network name and currency symbol) can be whatever value you like.
-
-:::
-
-### Additional Info
-
-<NetworkInfo.EvmCustom {...Networks['shimmer_testnet']}/>
 
 ## Core Contracts
 


### PR DESCRIPTION
# Description of change

The IOTA EVM Testnet and ShimmerEVM Testnet have duplicates on the [Networks and Chains page](https://wiki.iota.org/isc/getting-started/networks-and-chains/). This PR removes the duplicates.

## Links to any relevant issues

fixes issue #1605 .

## Type of change

- Documentation Enhancement

## Change checklist

- [x] I have followed the [contribution guidelines](https://github.com/iota-wiki/iota-wiki/blob/main/.github/CONTRIBUTING.md) for this project
- [x] I have performed a self-review of my own changes
- [x] I have made sure that added/changed links still work
