### PR TITLE
Update to newest wasp version

### DIFF
--- a/config/versionedConfig.js
+++ b/config/versionedConfig.js
@@ -28,7 +28,6 @@ exports.buildPluginsConfig = [
     versions: [
       {
         label: 'v1.1',
-        badges: [],
         banner: 'unmaintained',
       },
       {
@@ -155,7 +154,6 @@ exports.maintainPluginsConfig = [
     versions: [
       {
         label: 'v1.1',
-        badges: [],
         banner: 'unmaintained',
       },
       {

--- a/config/versionedConfig.js
+++ b/config/versionedConfig.js
@@ -28,12 +28,12 @@ exports.buildPluginsConfig = [
     versions: [
       {
         label: 'v1.1',
-        badges: ['IOTA'],
+        badges: [],
+        banner: 'unmaintained',
       },
       {
         label: 'v1.3',
-        badges: ['Shimmer', 'Testnet'],
-        banner: 'staging',
+        badges: ['IOTA', 'Shimmer', 'Testnet'],
       },
     ],
   },
@@ -155,12 +155,12 @@ exports.maintainPluginsConfig = [
     versions: [
       {
         label: 'v1.1',
-        badges: ['IOTA'],
+        badges: [],
+        banner: 'unmaintained',
       },
       {
         label: 'v1.3',
-        badges: ['Shimmer', 'Testnet'],
-        banner: 'staging',
+        badges: ['IOTA', 'Shimmer', 'Testnet'],
       },
     ],
   },

--- a/src/utils/pluginConfigGenerators.js
+++ b/src/utils/pluginConfigGenerators.js
@@ -4,17 +4,18 @@ const MAIN_BADGE = 'IOTA';
 
 /**
  * Find main version of a plugin by resolving it to the first version with the corresponding batch.
- * @param {import('../common/components/Switcher').Doc} plugin
+ * @param {import('../components/Switcher').Doc} plugin
+ * @param {string} badge
  */
 function findMainVersion(plugin, badge = MAIN_BADGE) {
   return plugin.versions.find((version) =>
-    version.badges.some((b) => b.includes(badge)),
+    version.badges ? version.badges.some((b) => b.includes(badge)) : false,
   );
 }
 
 /**
  * Generate the plugin config from the versioned config.
- * @param {import('../common/components/Switcher').Doc[]} pluginConfig
+ * @param {import('../components/Switcher').Doc[]} pluginConfig
  * @param {string} basePath
  */
 function generatePluginConfig(pluginConfig, basePath) {

--- a/src/utils/useSwitcher.ts
+++ b/src/utils/useSwitcher.ts
@@ -137,7 +137,9 @@ export default function useSwitcher(): SwitcherProps {
         // Resolve the doc link to the first MAIN_BADGE version.
         let to = versionLinks[0].to;
         const foundVersion = versionLinks.find((version) =>
-          version.badges.some((b) => b.includes(MAIN_BADGE)),
+          version.badges
+            ? version.badges.some((b) => b.includes(MAIN_BADGE))
+            : false,
         );
         if (foundVersion) to = foundVersion.to;
 


### PR DESCRIPTION
# Description of change

All networks are now running on version 1.3. So I marked 1.3 as stable and 1.1 as unmaintained

## Type of change

- Documentation Fix

## Change checklist

- [x] I have followed the [contribution guidelines](https://github.com/iota-wiki/iota-wiki/blob/main/.github/CONTRIBUTING.md) for this project
- [x] I have performed a self-review of my own changes
- [x] I have made sure that added/changed links still work
