### PR TITLE
fix(docs): update network and oracle pages

### DIFF
--- a/docs/build/_partials/_oracles_contract_data.mdx
+++ b/docs/build/_partials/_oracles_contract_data.mdx
@@ -29,7 +29,7 @@ import TabItem from '@theme/TabItem';
 You can find detailed documentation on the Oracles in their official documentation:
 
 * [Pyth Oracle Docs](https://docs.pyth.network/price-feeds/contract-addresses/evm)
-* [Supra Pull Docs](https://docs.supra.com/docs/data-feeds/pull-modelv1)
+* [Supra Pull Docs](https://docs.supra.com/docs/data-feeds/pull-model)
 * [Supra Push Docs](https://docs.supra.com/docs/data-feeds/decentralized)
 
 :::

--- a/docs/build/_partials/_oracles_contract_data.mdx
+++ b/docs/build/_partials/_oracles_contract_data.mdx
@@ -28,8 +28,8 @@ import TabItem from '@theme/TabItem';
 
 You can find detailed documentation on the Oracles in their official documentation:
 
-* [Pyth Oracle Docs](https://docs.pyth.network/price-feeds/contract-addresses/evm) 
-* [Supra Pull Docs](https://gb-docs.supraoracles.com/docs/data-feeds/pull-model/networks)
-* [Supra Push Docs](https://gb-docs.supraoracles.com/docs/data-feeds/decentralized/networks)
+* [Pyth Oracle Docs](https://docs.pyth.network/price-feeds/contract-addresses/evm)
+* [Supra Pull Docs](https://docs.supra.com/docs/data-feeds/pull-modelv1)
+* [Supra Push Docs](https://docs.supra.com/docs/data-feeds/decentralized)
 
 :::

--- a/src/theme/NetworkInfo/index.tsx
+++ b/src/theme/NetworkInfo/index.tsx
@@ -34,6 +34,14 @@ function L1(props: NetworkProps) {
             <CodeBlock>{props.permaNodeApi}</CodeBlock>
           </td>
         </tr>
+        <tr>
+          <th>Explorer</th>
+          <td>
+            <a href={props.explorer} target='_blank' rel='noopener noreferrer'>
+              {props.explorer}
+            </a>
+          </td>
+        </tr>
         {props.faucet && (
           <tr>
             <th>Faucet</th>


### PR DESCRIPTION
# Description of change

This PR updates the Network and Oracle pages on the wiki. Some networks do not show network explorer URLs on their tables, and the URLs pointing to the Supra Oracle documentation were broken and had to be updated.

## Links to any relevant issues

`fixes #1666 

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Documentation Fix

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the [contribution guidelines](https://github.com/iota-wiki/iota-wiki/blob/main/.github/CONTRIBUTING.md) for this project
- [x] I have performed a self-review of my own changes
- [x] I have made sure that added/changed links still work
